### PR TITLE
Fix microstate clustering edge cases

### DIFF
--- a/src/pmarlo/cluster/micro.py
+++ b/src/pmarlo/cluster/micro.py
@@ -14,13 +14,15 @@ def cluster_microstates(
     **kwargs,
 ) -> np.ndarray:
     """Cluster reduced data into microstates and return labels."""
-    if Y.size == 0:
+    if Y.shape[0] == 0:
         return np.zeros((0,), dtype=int)
+    if Y.shape[1] == 0:
+        raise ValueError("Input array must have at least one feature")
     if method == "minibatchkmeans":
         km = MiniBatchKMeans(n_clusters=n_clusters, random_state=random_state, **kwargs)
     elif method == "kmeans":
         km = KMeans(
-            n_clusters=n_clusters, random_state=random_state, n_init="auto", **kwargs
+            n_clusters=n_clusters, random_state=random_state, n_init=10, **kwargs
         )
     else:
         raise ValueError(f"Unsupported clustering method: {method}")

--- a/tests/test_cluster_micro.py
+++ b/tests/test_cluster_micro.py
@@ -1,0 +1,27 @@
+import numpy as np
+import pytest
+from unittest.mock import patch
+
+from pmarlo.cluster.micro import cluster_microstates
+
+
+def test_returns_empty_for_no_samples():
+    Y = np.empty((0, 2))
+    labels = cluster_microstates(Y, n_clusters=2)
+    assert labels.size == 0
+    assert labels.dtype == int
+
+
+def test_raises_for_no_features():
+    Y = np.empty((3, 0))
+    with pytest.raises(ValueError, match="at least one feature"):
+        cluster_microstates(Y)
+
+
+def test_kmeans_uses_int_n_init():
+    Y = np.random.rand(10, 2)
+    with patch("pmarlo.cluster.micro.KMeans") as mock_kmeans:
+        instance = mock_kmeans.return_value
+        instance.fit_predict.return_value = np.zeros(10, dtype=int)
+        cluster_microstates(Y, method="kmeans", n_clusters=2)
+        assert isinstance(mock_kmeans.call_args.kwargs["n_init"], int)


### PR DESCRIPTION
## Summary
- handle empty sample and feature cases in `cluster_microstates`
- replace `n_init='auto'` with integer for wider scikit-learn compatibility
- add unit tests for microstate clustering

## Testing
- `PYTHONPATH=src pytest -q` *(fails: PDBFixer missing)*
- `tox -q` *(fails: flake8 & mypy/lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68aa0ff5c86c832ea32f053b2d6d0269