### PR TITLE
fix: stabilize experiment seeds and path helpers

### DIFF
--- a/src/pmarlo/experiments/cli.py
+++ b/src/pmarlo/experiments/cli.py
@@ -6,14 +6,15 @@ from pathlib import Path
 from .msm import MSMConfig, run_msm_experiment
 from .replica_exchange import ReplicaExchangeConfig, run_replica_exchange_experiment
 from .simulation import SimulationConfig, run_simulation_experiment
+from .utils import tests_data_dir
 
 # CLI sets logging level; modules themselves do not configure basicConfig
 
 
 def _tests_data_dir() -> Path:
-    # Resolve to package root / tests / data
-    here = Path(__file__).resolve().parents[2]
-    return here / "tests" / "data"
+    """Return the path to ``tests/data`` for use as CLI defaults."""
+
+    return tests_data_dir()
 
 
 def main():

--- a/src/pmarlo/experiments/msm.py
+++ b/src/pmarlo/experiments/msm.py
@@ -26,7 +26,7 @@ from .kpi import (
     default_kpi_metrics,
     write_benchmark_json,
 )
-from .utils import timestamp_dir
+from .utils import set_seed, timestamp_dir
 
 logger = logging.getLogger(__name__)
 
@@ -40,6 +40,7 @@ class MSMConfig:
     lag_time: int = 20
     feature_type: str = "phi_psi"
     temperatures: List[float] | None = None
+    seed: int | None = None
 
 
 def _create_run_directory(output_dir: str) -> Path:
@@ -224,7 +225,7 @@ def _build_enriched_input(
         "seconds_per_step": None,
         "num_exchange_attempts": None,
         "overall_acceptance_rate": None,
-        "seed": None,
+        "seed": config.seed,
     }
 
 
@@ -279,6 +280,7 @@ def run_msm_experiment(config: MSMConfig) -> Dict:
 
     Returns a dictionary pointing to the run directory and summary file content.
     """
+    set_seed(config.seed)
     run_dir = _create_run_directory(config.output_dir)
 
     msm, tracker = _perform_msm_analysis_with_tracking(config, run_dir)

--- a/src/pmarlo/experiments/replica_exchange.py
+++ b/src/pmarlo/experiments/replica_exchange.py
@@ -22,7 +22,7 @@ from .kpi import (
     default_kpi_metrics,
     write_benchmark_json,
 )
-from .utils import timestamp_dir
+from .utils import set_seed, timestamp_dir
 
 logger = logging.getLogger(__name__)
 
@@ -39,6 +39,7 @@ class ReplicaExchangeConfig:
     tmin: float = 300.0
     tmax: float = 350.0
     nreplicas: int = 6
+    seed: int | None = None
 
 
 def run_replica_exchange_experiment(config: ReplicaExchangeConfig) -> Dict:
@@ -46,6 +47,7 @@ def run_replica_exchange_experiment(config: ReplicaExchangeConfig) -> Dict:
     Runs Stage 2: REMD with multi-temperature replicas from a prepared PDB.
     Returns a dict with exchange statistics and artifact paths.
     """
+    set_seed(config.seed)
     run_dir = timestamp_dir(config.output_dir)
 
     # Minimal checkpointing confined to this experiment run dir
@@ -85,6 +87,7 @@ def run_replica_exchange_experiment(config: ReplicaExchangeConfig) -> Dict:
                 exchange_frequency=config.exchange_frequency,
                 dcd_stride=2000,
                 auto_setup=False,
+                random_seed=config.seed,
             )
         )
     else:
@@ -95,6 +98,7 @@ def run_replica_exchange_experiment(config: ReplicaExchangeConfig) -> Dict:
             output_dir=str(run_dir / "remd"),
             exchange_frequency=config.exchange_frequency,
             auto_setup=False,
+            random_seed=config.seed,
         )
 
     bias_vars = (
@@ -158,7 +162,7 @@ def run_replica_exchange_experiment(config: ReplicaExchangeConfig) -> Dict:
         "frames_per_second": None,
         "spectral_gap": None,
         "row_stochasticity_mad": None,
-        "seed": None,
+        "seed": config.seed,
         "num_frames": None,
     }
 

--- a/src/pmarlo/experiments/simulation.py
+++ b/src/pmarlo/experiments/simulation.py
@@ -28,7 +28,7 @@ from .kpi import (
     default_kpi_metrics,
     write_benchmark_json,
 )
-from .utils import timestamp_dir
+from .utils import set_seed, timestamp_dir
 
 logger = logging.getLogger(__name__)
 
@@ -41,6 +41,7 @@ class SimulationConfig:
     temperature: float = 300.0
     n_states: int = 40
     use_metadynamics: bool = True
+    seed: int | None = None
 
 
 def _create_run_dir(output_root: str) -> Path:
@@ -251,7 +252,7 @@ def _enrich_input(
         "detailed_balance_mad": detailed_balance_mad,
         "ck_mse_factor2": ck_mse_factor2,
         **get_environment_info(),
-        "seed": None,
+        "seed": config.seed,
         "num_frames": metrics.get("num_frames"),
         "num_exchange_attempts": None,
     }
@@ -308,6 +309,7 @@ def run_simulation_experiment(config: SimulationConfig) -> Dict:
     equilibration using the existing Pipeline with use_replica_exchange=False.
     Returns a dict with artifact paths and quick metrics.
     """
+    set_seed(config.seed)
     run_dir = _create_run_dir(config.output_dir)
     pipeline = _configure_pipeline(config, run_dir)
     _setup_protein_with_fallback(pipeline, config.pdb_file)

--- a/src/pmarlo/experiments/suite.py
+++ b/src/pmarlo/experiments/suite.py
@@ -29,6 +29,7 @@ from typing import Literal, TypedDict
 from .msm import MSMConfig, run_msm_experiment
 from .replica_exchange import ReplicaExchangeConfig, run_replica_exchange_experiment
 from .simulation import SimulationConfig, run_simulation_experiment
+from .utils import tests_data_dir
 
 AlgorithmName = Literal["simulation", "remd", "msm"]
 
@@ -59,12 +60,15 @@ class SuiteCase:
 
 
 def _tests_pdb() -> str:
-    # Tests data live under repo/tests/data in this project layout
-    return "tests/data/3gd8-fixed.pdb"
+    """Return the path to the test PDB file."""
+
+    return str(tests_data_dir() / "3gd8-fixed.pdb")
 
 
 def _tests_traj() -> list[str]:
-    return ["tests/data/traj.dcd"]
+    """Return paths to the default test trajectories."""
+
+    return [str(tests_data_dir() / "traj.dcd")]
 
 
 def get_suite_cases() -> list[SuiteCase]:
@@ -133,6 +137,7 @@ def run_suite_case(index: int) -> SuiteResult:
             # internally by the experiment function
             steps=int(c.sim_steps or 500),
             use_metadynamics=bool(c.sim_use_metadynamics is True),
+            seed=0,
         )
         res = run_simulation_experiment(sim_cfg)
     elif c.algorithm == "remd":
@@ -143,6 +148,7 @@ def run_suite_case(index: int) -> SuiteResult:
             nreplicas=int(c.remd_nrep or 6),
             tmin=float(c.remd_tmin or 300.0),
             tmax=float(c.remd_tmax or 350.0),
+            seed=0,
         )
         res = run_replica_exchange_experiment(remd_cfg)
     else:
@@ -151,6 +157,7 @@ def run_suite_case(index: int) -> SuiteResult:
             topology_file=_tests_pdb(),
             n_clusters=int(c.msm_clusters or 60),
             lag_time=int(c.msm_lag or 20),
+            seed=0,
         )
         res = run_msm_experiment(msm_cfg)
 

--- a/src/pmarlo/experiments/utils.py
+++ b/src/pmarlo/experiments/utils.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 from datetime import datetime
+import random
 from pathlib import Path
 from typing import Union
+
+import numpy as np
 
 
 def timestamp_dir(base_dir: Union[str, Path]) -> Path:
@@ -15,3 +18,22 @@ def timestamp_dir(base_dir: Union[str, Path]) -> Path:
     run_dir = Path(base_dir) / ts
     run_dir.mkdir(parents=True, exist_ok=True)
     return run_dir
+
+
+def tests_data_dir() -> Path:
+    """Return the repository's ``tests/data`` directory.
+
+    Resolves the path relative to this source file so it works whether the
+    project is run from a source checkout or an installed package.
+    """
+
+    return Path(__file__).resolve().parents[3] / "tests" / "data"
+
+
+def set_seed(seed: int | None) -> None:
+    """Seed Python and NumPy RNGs for experiment reproducibility."""
+
+    if seed is None:
+        return
+    random.seed(int(seed))
+    np.random.seed(int(seed))

--- a/tests/test_experiments_paths.py
+++ b/tests/test_experiments_paths.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+from pmarlo.experiments.cli import _tests_data_dir
+from pmarlo.experiments.suite import _tests_pdb, _tests_traj
+
+
+def test_cli_tests_data_dir_points_to_repo_tests():
+    data_dir = _tests_data_dir()
+    assert (data_dir / "3gd8-fixed.pdb").exists()
+
+
+def test_suite_helpers_resolve_test_data():
+    assert Path(_tests_pdb()).exists()
+    for p in _tests_traj():
+        assert Path(p).exists()

--- a/tests/test_experiments_seed.py
+++ b/tests/test_experiments_seed.py
@@ -1,0 +1,128 @@
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+
+from pmarlo.experiments.simulation import SimulationConfig, run_simulation_experiment
+from pmarlo.experiments.replica_exchange import (
+    ReplicaExchangeConfig,
+    run_replica_exchange_experiment,
+)
+from pmarlo.experiments.msm import MSMConfig, run_msm_experiment
+
+
+def test_simulation_experiment_uses_seed(monkeypatch, tmp_path):
+    captured = {}
+    monkeypatch.setattr(
+        "pmarlo.experiments.simulation.set_seed", lambda s: captured.setdefault("seed", s)
+    )
+
+    dummy_states = np.array([0, 1])
+
+    class DummySim:
+        def __init__(self):
+            self.output_dir = tmp_path
+
+        def prepare_system(self):
+            return object(), None
+
+        def run_production(self, *_args, **_kwargs):
+            p = tmp_path / "simulation" / "traj.dcd"
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_bytes(b"")
+            return str(p)
+
+        def extract_features(self, _traj):
+            return dummy_states
+
+    with patch("pmarlo.experiments.simulation.Pipeline") as MockPipe:
+        pipe = MockPipe.return_value
+        pipe.setup_protein.return_value = MagicMock()
+        pipe.setup_simulation.return_value = DummySim()
+        pipe.prepared_pdb = Path("tests/data/3gd8-fixed.pdb")
+
+        cfg = SimulationConfig(
+            pdb_file="tests/data/3gd8-fixed.pdb",
+            output_dir=str(tmp_path),
+            steps=5,
+            use_metadynamics=False,
+            seed=123,
+        )
+        run_simulation_experiment(cfg)
+
+    assert captured["seed"] == 123
+
+
+def test_replica_exchange_experiment_uses_seed(monkeypatch, tmp_path):
+    captured = {}
+    monkeypatch.setattr(
+        "pmarlo.experiments.replica_exchange.set_seed",
+        lambda s: captured.setdefault("seed", s),
+    )
+
+    class DummyREMD:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        @classmethod
+        def from_config(cls, cfg):
+            assert cfg.random_seed == 456
+            return cls()
+
+        def setup_replicas(self, **_):
+            pass
+
+        def run_simulation(self, **_):
+            pass
+
+        def get_exchange_statistics(self):
+            return {}
+
+    with patch("pmarlo.experiments.replica_exchange.ReplicaExchange", DummyREMD):
+        cfg = ReplicaExchangeConfig(
+            pdb_file="tests/data/3gd8-fixed.pdb",
+            output_dir=str(tmp_path),
+            total_steps=10,
+            equilibration_steps=2,
+            exchange_frequency=5,
+            use_metadynamics=False,
+            seed=456,
+        )
+        run_replica_exchange_experiment(cfg)
+
+    assert captured["seed"] == 456
+
+
+def test_msm_experiment_uses_seed(monkeypatch, tmp_path):
+    captured = {}
+    monkeypatch.setattr(
+        "pmarlo.experiments.msm.set_seed", lambda s: captured.setdefault("seed", s)
+    )
+
+    class DummyMSMObj:
+        def __init__(self):
+            import numpy as np
+
+            self.n_states = 2
+            self.transition_matrix = np.array([[1.0, 0.0], [0.0, 1.0]])
+            self.dtrajs = [np.array([0, 1, 0, 1])]
+            self.lag_time = 1
+
+    def dummy_run_complete(*_args, **_kwargs):
+        (tmp_path / "msm").mkdir(parents=True, exist_ok=True)
+        return DummyMSMObj()
+
+    with patch(
+        "pmarlo.experiments.msm.run_complete_msm_analysis", dummy_run_complete
+    ):
+        cfg = MSMConfig(
+            trajectory_files=["tests/data/traj.dcd"],
+            topology_file="tests/data/3gd8-fixed.pdb",
+            output_dir=str(tmp_path),
+            n_clusters=5,
+            lag_time=10,
+            seed=789,
+        )
+        run_msm_experiment(cfg)
+
+    assert captured["seed"] == 789


### PR DESCRIPTION
## Summary
- add shared `tests_data_dir` and RNG `set_seed` utilities
- ensure CLI and suite resolve test data via package paths
- allow experiments to accept seeds for reproducible runs
- add tests for path helpers and seeding

## Testing
- `PYTHONPATH=src pytest tests/test_experiments_paths.py tests/test_experiments_seed.py tests/test_experiments_kpi.py -q`
- `tox -q -e lint` *(fails: C901 in api.py and unused imports in unit tests)*

------
https://chatgpt.com/codex/tasks/task_e_68aa0ffc9d80832e98a37eca8e22698d