### PR TITLE
Improve reporting plot reliability and add tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ dist/
 .venv/
 env/
 venv/
+.tox/
 
 # OS files
 .DS_Store

--- a/src/pmarlo/reporting/plots.py
+++ b/src/pmarlo/reporting/plots.py
@@ -3,29 +3,35 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Optional
 
-import matplotlib.pyplot as plt
 import numpy as np
 
 
 def save_transition_matrix_heatmap(
     T: np.ndarray, output_dir: str, name: str = "T_heatmap.png"
 ) -> Optional[str]:
+    """Save a heatmap of a transition matrix to ``output_dir``.
+
+    Returns the path to the written file if successful, otherwise ``None``.
+    """
+
     try:
-        out_dir = Path(output_dir)
-        out_dir.mkdir(parents=True, exist_ok=True)
-        plt.figure(figsize=(6, 5))
-        plt.imshow(T, cmap="viridis", origin="lower")
-        plt.colorbar(label="Transition Prob.")
-        plt.xlabel("j")
-        plt.ylabel("i")
-        plt.title("Transition Matrix")
-        filepath = out_dir / name
-        plt.tight_layout()
-        plt.savefig(filepath, dpi=200)
-        plt.close()
-        return str(filepath)
-    except Exception:
-        return None
+        import matplotlib.pyplot as plt
+    except ImportError as exc:  # pragma: no cover
+        raise RuntimeError("matplotlib is required for plotting") from exc
+
+    out_dir = Path(output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    plt.figure(figsize=(6, 5))
+    plt.imshow(T, cmap="viridis", origin="lower")
+    plt.colorbar(label="Transition Probability")
+    plt.xlabel("j")
+    plt.ylabel("i")
+    plt.title("Transition Matrix")
+    filepath = out_dir / name
+    plt.tight_layout()
+    plt.savefig(filepath, dpi=200)
+    plt.close()
+    return str(filepath) if filepath.exists() else None
 
 
 def save_fes_contour(
@@ -38,20 +44,22 @@ def save_fes_contour(
     filename: str,
 ) -> Optional[str]:
     try:
-        out_dir = Path(output_dir)
-        out_dir.mkdir(parents=True, exist_ok=True)
-        x_centers = 0.5 * (xedges[:-1] + xedges[1:])
-        y_centers = 0.5 * (yedges[:-1] + yedges[1:])
-        plt.figure(figsize=(7, 6))
-        c = plt.contourf(x_centers, y_centers, F.T, levels=20, cmap="viridis")
-        plt.colorbar(c, label="Free Energy (kJ/mol)")
-        plt.xlabel(xlabel)
-        plt.ylabel(ylabel)
-        plt.title(f"FES ({xlabel} vs {ylabel})")
-        filepath = out_dir / filename
-        plt.tight_layout()
-        plt.savefig(filepath, dpi=200)
-        plt.close()
-        return str(filepath)
-    except Exception:
-        return None
+        import matplotlib.pyplot as plt
+    except ImportError as exc:  # pragma: no cover
+        raise RuntimeError("matplotlib is required for plotting") from exc
+
+    out_dir = Path(output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    x_centers = 0.5 * (xedges[:-1] + xedges[1:])
+    y_centers = 0.5 * (yedges[:-1] + yedges[1:])
+    plt.figure(figsize=(7, 6))
+    c = plt.contourf(x_centers, y_centers, F.T, levels=20, cmap="viridis")
+    plt.colorbar(c, label="Free Energy (kJ/mol)")
+    plt.xlabel(xlabel)
+    plt.ylabel(ylabel)
+    plt.title(f"FES ({xlabel} vs {ylabel})")
+    filepath = out_dir / filename
+    plt.tight_layout()
+    plt.savefig(filepath, dpi=200)
+    plt.close()
+    return str(filepath) if filepath.exists() else None

--- a/tests/reporting/test_export.py
+++ b/tests/reporting/test_export.py
@@ -1,0 +1,10 @@
+import numpy as np
+
+from pmarlo.reporting.export import write_conformations_csv_json
+
+
+def test_write_conformations_csv_json(tmp_path):
+    items = [{"id": 1, "array": np.array([1, 2]), "scalar": np.float64(1.2)}]
+    write_conformations_csv_json(str(tmp_path), items)
+    assert (tmp_path / "conformations_summary.csv").exists()
+    assert (tmp_path / "states.json").exists()

--- a/tests/reporting/test_plots.py
+++ b/tests/reporting/test_plots.py
@@ -1,0 +1,22 @@
+import numpy as np
+from pathlib import Path
+
+from pmarlo.reporting.plots import save_transition_matrix_heatmap, save_fes_contour
+
+
+def test_save_transition_matrix_heatmap(tmp_path):
+    T = np.array([[0.5, 0.5], [0.5, 0.5]])
+    path = save_transition_matrix_heatmap(T, output_dir=str(tmp_path))
+    assert path is not None
+    assert Path(path).exists()
+
+
+def test_save_fes_contour(tmp_path):
+    F = np.random.rand(5, 5)
+    xedges = np.linspace(0, 1, 6)
+    yedges = np.linspace(0, 1, 6)
+    path = save_fes_contour(
+        F, xedges, yedges, "X", "Y", str(tmp_path), "fes.png"
+    )
+    assert path is not None
+    assert Path(path).exists()


### PR DESCRIPTION
## Summary
- fix transition matrix heatmap label and verify saved paths
- guard plotting functions against missing matplotlib
- add tests for report exports and plotting utilities

## Testing
- `PYTHONPATH=src python -m pytest tests/reporting/test_plots.py tests/reporting/test_export.py -q`
- `tox -e py311 -- tests/reporting/test_plots.py tests/reporting/test_export.py` *(fails: py311 interpreter missing)*
- `tox -e lint` *(fails: flake8 errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68aa103c6f60832eb9fd7acd22c2a6aa