### PR TITLE
Ensure stable macrostate labels and JSON mapping

### DIFF
--- a/src/pmarlo/states/__init__.py
+++ b/src/pmarlo/states/__init__.py
@@ -1,3 +1,16 @@
 """Bridges and helpers around MSM construction from microstate labels."""
 
-from .msm_bridge import build_simple_msm  # noqa: F401
+from .msm_bridge import (
+    build_simple_msm,
+    deserialize_macro_mapping,
+    pcca_like_macrostates,
+    serialize_macro_mapping,
+)
+
+__all__ = [
+    "build_simple_msm",
+    "pcca_like_macrostates",
+    "serialize_macro_mapping",
+    "deserialize_macro_mapping",
+]
+

--- a/tests/unit/test_states.py
+++ b/tests/unit/test_states.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from pmarlo.states import (
+    deserialize_macro_mapping,
+    pcca_like_macrostates,
+    serialize_macro_mapping,
+)
+
+
+def _example_T() -> np.ndarray:
+    """Small transition matrix with two metastable basins."""
+    return np.array(
+        [
+            [0.9, 0.1, 0.0, 0.0],
+            [0.1, 0.8, 0.1, 0.0],
+            [0.0, 0.1, 0.8, 0.1],
+            [0.0, 0.0, 0.1, 0.9],
+        ],
+        dtype=float,
+    )
+
+
+def test_pcca_label_stability() -> None:
+    pytest.importorskip("sklearn")
+    T = _example_T()
+    labels1 = pcca_like_macrostates(T, n_macrostates=2)
+    labels2 = pcca_like_macrostates(T, n_macrostates=2)
+    assert labels1 is not None and labels2 is not None
+    assert np.array_equal(labels1, labels2)
+    assert set(labels1.tolist()) == {0, 1}
+
+
+def test_serialization_roundtrip() -> None:
+    labels = np.array([0, 1, 1, 0], dtype=int)
+    blob = serialize_macro_mapping(labels)
+    restored = deserialize_macro_mapping(blob)
+    assert np.array_equal(labels, restored)
+


### PR DESCRIPTION
## Summary
- ignore negative labels when inferring microstate count
- canonicalize PCCA+ macrostate labels for deterministic ordering
- add JSON serialization helpers for micro→macro mapping
- expose new helpers and add unit tests for label stability and serialization

## Testing
- `PYTHONPATH=src pytest tests/unit/test_states.py -q`
- `PYTHONPATH=src pytest -q` *(fails: PDBFixer is required for protein preparation but is not installed)*
- `tox -q -e py312-no-pdbfixer` *(fails: interrupted during environment setup)*

------
https://chatgpt.com/codex/tasks/task_e_68aa104b9134832eb36a680ed7d48a43