### PR TITLE
Improve feature extraction robustness and add edge tests

### DIFF
--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1,0 +1,52 @@
+import numpy as np
+import pytest
+import mdtraj as md
+from mdtraj.core.element import carbon
+
+from pmarlo.features import get_feature
+from pmarlo.features.base import parse_feature_spec
+from pmarlo.features.builtins import DistancePairFeature, ContactsPairFeature
+
+
+def _simple_traj(distance: float = 0.5, *, nan: bool = False) -> md.Trajectory:
+    top = md.Topology()
+    chain = top.add_chain()
+    res = top.add_residue("GLY", chain)
+    top.add_atom("A", carbon, res)
+    top.add_atom("B", carbon, res)
+    coords = np.array([[[0.0, 0.0, 0.0], [distance, 0.0, 0.0]]], dtype=float)
+    if nan:
+        coords[0, 1, :] = np.nan
+    return md.Trajectory(coords, top)
+
+
+def test_case_insensitive_feature_lookup() -> None:
+    name, kwargs = parse_feature_spec("rg")
+    feat = get_feature(name)
+    traj = _simple_traj()
+    X = feat.compute(traj, **kwargs)
+    assert X.shape == (1, 1)
+
+
+def test_distance_pair_validation_and_nan() -> None:
+    traj = _simple_traj(nan=True)
+    feat = DistancePairFeature()
+    X = feat.compute(traj, i=0, j=1)
+    assert np.all(np.isfinite(X))
+    with pytest.raises(ValueError):
+        feat.compute(traj, i=0, j=2)
+
+
+def test_contacts_pair_boundary_and_validation() -> None:
+    traj = _simple_traj(distance=0.5)
+    feat = ContactsPairFeature()
+    X = feat.compute(traj, i=0, j=1, rcut=0.5)
+    assert X[0, 0] == 1.0
+    traj_nan = _simple_traj(nan=True)
+    X_nan = feat.compute(traj_nan, i=0, j=1, rcut=0.5)
+    assert X_nan[0, 0] == 0.0
+    with pytest.raises(ValueError):
+        feat.compute(traj, i=0, j=2, rcut=0.5)
+    with pytest.raises(ValueError):
+        feat.compute(traj, i=0, j=1, rcut=-1.0)
+


### PR DESCRIPTION
## Summary
- handle feature names case-insensitively and normalize specifications
- validate atom indices & radius in distance/contact features and guard against NaNs
- add tests for case-insensitive lookup, NaN sanitization, and boundary contacts

## Testing
- `PYTHONPATH=src pytest tests/test_features.py -q`
- `PYTHONPATH=src pytest -q` *(fails: PDBFixer is required for protein tests)*
- `tox -q -e py311-no-pdbfixer` *(fails: environment skipped/missing)*

------
https://chatgpt.com/codex/tasks/task_e_68aa1003dc08832e87adb3b6547ccb6d