### PR TITLE
Fix FESResult attribute access

### DIFF
--- a/example_programs/find_conformations_with_msm.py
+++ b/example_programs/find_conformations_with_msm.py
@@ -257,8 +257,8 @@ def run_conformation_finder(
     items.append(
         {
             "type": "FES",
-            "bins_x": int(len(fes["xedges"]) - 1),
-            "bins_y": int(len(fes["yedges"]) - 1),
+            "bins_x": int(len(fes.xedges) - 1),
+            "bins_y": int(len(fes.yedges) - 1),
             "pair": {"x": names[0], "y": names[1]},
             "periodic": {"x": bool(per_i), "y": bool(per_j)},
         }
@@ -286,7 +286,7 @@ def run_conformation_finder(
     # Save a FES plot with a filename reflecting the selected pair
     fname = f"fes_{_sanitize(names[0])}_vs_{_sanitize(names[1])}.png"
     _ = save_fes_contour(
-        fes["F"], fes["xedges"], fes["yedges"], names[0], names[1], str(OUT_DIR), fname
+        fes.F, fes.xedges, fes.yedges, names[0], names[1], str(OUT_DIR), fname
     )
 
     write_conformations_csv_json(str(OUT_DIR), items)

--- a/src/pmarlo/api.py
+++ b/src/pmarlo/api.py
@@ -9,7 +9,7 @@ import numpy as np
 from .cluster.micro import cluster_microstates as _cluster_microstates
 from .features import get_feature
 from .features.base import parse_feature_spec
-from .fes.surfaces import generate_2d_fes as _generate_2d_fes
+from .fes.surfaces import FESResult, generate_2d_fes as _generate_2d_fes
 from .markov_state_model.markov_state_model import EnhancedMSM as MarkovStateModel
 from .reduce.reducers import pca_reduce, tica_reduce, vamp_reduce
 from .replica_exchange.config import RemdConfig
@@ -110,7 +110,29 @@ def generate_free_energy_surface(
     temperature: float = 300.0,
     periodic: Tuple[bool, bool] = (False, False),
     smoothing: Optional[Literal["cosine"]] = None,
-) -> dict:
+) -> FESResult:
+    """Generate a 2D free-energy surface.
+
+    Parameters
+    ----------
+    cv1, cv2
+        Collective variable samples.
+    bins
+        Number of histogram bins in ``(x, y)``.
+    temperature
+        Simulation temperature in Kelvin.
+    periodic
+        Flags indicating whether each dimension is periodic.
+    smoothing
+        Placeholder smoothing option; currently only ``"cosine"`` is
+        recognised.
+
+    Returns
+    -------
+    FESResult
+        Dataclass containing the free-energy surface and bin edges.
+    """
+
     # Map smoothing flag to gaussian sigma; cosine placeholder maps to 0.6
     sigma = 0.6 if smoothing == "cosine" else 0.6
     out = _generate_2d_fes(
@@ -297,7 +319,7 @@ def generate_fes_and_pick_minima(
         smoothing=smoothing,
     )
     minima = _pick_frames_around_minima(
-        cv1, cv2, fes["F"], fes["xedges"], fes["yedges"], deltaF_kJmol=deltaF_kJmol
+        cv1, cv2, fes.F, fes.xedges, fes.yedges, deltaF_kJmol=deltaF_kJmol
     )
     return {
         "i": int(i),
@@ -563,7 +585,7 @@ def find_conformations(
     minima = fes_info["minima"]
     fname = f"fes_{sanitize_label_for_filename(names[0])}_vs_{sanitize_label_for_filename(names[1])}.png"
     _ = save_fes_contour(
-        fes["F"], fes["xedges"], fes["yedges"], names[0], names[1], str(out), fname
+        fes.F, fes.xedges, fes.yedges, names[0], names[1], str(out), fname
     )
 
     for idx, entry in enumerate(minima.get("minima", [])):

--- a/tests/test_fes.py
+++ b/tests/test_fes.py
@@ -31,7 +31,11 @@ def test_generate_2d_fes_reference():
     res = generate_2d_fes(x, y, bins=(20, 20), temperature=300.0, smoothing_sigma=None)
     assert isinstance(res, FESResult)
     H, xedges, yedges = np.histogram2d(
-        x, y, bins=(20, 20), range=((x.min(), x.max()), (y.min(), y.max())), density=True
+        x,
+        y,
+        bins=(20, 20),
+        range=((x.min(), x.max()), (y.min(), y.max())),
+        density=True,
     )
     kT = _kT_kJ_per_mol(300.0)
     tiny = np.finfo(float).tiny
@@ -39,7 +43,7 @@ def test_generate_2d_fes_reference():
     F_ref = np.where(H > 0, -kT * np.log(H_clipped), np.inf)
     F_ref -= np.nanmin(F_ref)
     assert np.allclose(res.F, F_ref)
-    assert np.allclose(res.counts, H)
+    assert np.allclose(res.metadata["counts"], H)
 
 
 def test_generate_2d_fes_shape_mismatch():
@@ -53,4 +57,3 @@ def test_generate_1d_pmf_invalid_temperature():
     data = np.array([0.0, 1.0])
     with pytest.raises(ValueError):
         generate_1d_pmf(data, temperature=-1.0)
-

--- a/tests/test_fes_result_api.py
+++ b/tests/test_fes_result_api.py
@@ -1,0 +1,36 @@
+import numpy as np
+import pytest
+
+from pmarlo.api import generate_fes_and_pick_minima
+from pmarlo.fes import FESResult
+
+
+def test_fesresult_attribute_and_mapping_access():
+    fes = FESResult(
+        F=np.zeros((1, 1)),
+        xedges=np.array([0.0, 1.0]),
+        yedges=np.array([0.0, 1.0]),
+    )
+    assert fes.F.shape == (1, 1)
+    with pytest.warns(DeprecationWarning):
+        assert np.array_equal(fes["F"], fes.F)
+
+
+def test_generate_fes_and_pick_minima_runs():
+    rng = np.random.default_rng(0)
+    X = rng.normal(size=(50, 2))
+    cols = ["a", "b"]
+    periodic = np.array([False, False])
+    res = generate_fes_and_pick_minima(
+        X,
+        cols,
+        periodic,
+        requested_pair=("a", "b"),
+        bins=(10, 10),
+        temperature=300.0,
+        smoothing="cosine",
+        deltaF_kJmol=1.0,
+    )
+    fes = res["fes"]
+    assert isinstance(fes, FESResult)
+    assert fes.F.ndim == 2


### PR DESCRIPTION
## Summary
- refactor FESResult into a dataclass with explicit attributes and metadata
- update FES-related API and examples to use attribute access instead of dict indexing
- add backward-compatibility warning for mapping-style access and corresponding tests

## Testing
- `ruff check src/pmarlo/fes/surfaces.py src/pmarlo/api.py example_programs/find_conformations_with_msm.py tests/test_fes.py tests/test_fes_result_api.py`
- `black --check src/pmarlo/fes/surfaces.py src/pmarlo/api.py example_programs/find_conformations_with_msm.py tests/test_fes.py tests/test_fes_result_api.py`
- `mypy src/pmarlo/fes/surfaces.py src/pmarlo/api.py` *(fails: Name "List" is not defined and other type errors in unrelated modules)*
- `PYTHONPATH=src pytest tests/test_fes.py tests/test_fes_result_api.py tests/reporting/test_plots.py -q`
- `PYTHONPATH=src python example_programs/all_capabilities_demo.py` *(terminated: long-running simulation)*

------
https://chatgpt.com/codex/tasks/task_e_68aa20d1cf34832e81042dbcd2e6a240