### PR TITLE
feat: add deterministic microstate clustering

### DIFF
--- a/example_programs/find_conformations_with_msm.py
+++ b/example_programs/find_conformations_with_msm.py
@@ -94,7 +94,7 @@ def run_conformation_finder(
     X, cols, periodic = api.compute_features(traj, feature_specs=specs)
     # Try VAMP for robustness; fallback remains in api if unavailable
     Y = api.reduce_features(X, method="vamp", lag=10, n_components=3)
-    labels = api.cluster_microstates(Y, method="minibatchkmeans", n_clusters=20)
+    labels = api.cluster_microstates(Y, method="minibatchkmeans", n_states=20)
 
     # 2) MSM from labels → macrostates (PCCA+-like)
     dtrajs = [labels]  # single trajectory

--- a/src/pmarlo/api.py
+++ b/src/pmarlo/api.py
@@ -97,10 +97,38 @@ def reduce_features(
 
 def cluster_microstates(
     Y: np.ndarray,
-    method: Literal["minibatchkmeans", "kmeans"] = "minibatchkmeans",
+    method: Literal["minibatchkmeans", "kmeans"] = "kmeans",
+    n_states: int | Literal["auto"] = "auto",
+    random_state: int = 42,
     **kwargs,
 ) -> np.ndarray:
-    return _cluster_microstates(Y, method=method, **kwargs)
+    """Public wrapper around :func:`cluster.micro.cluster_microstates`.
+
+    Parameters
+    ----------
+    Y:
+        Reduced feature array.
+    method:
+        Clustering algorithm to use.
+    n_states:
+        Number of states or ``"auto"`` to select via silhouette.
+    random_state:
+        Seed for deterministic clustering.
+
+    Returns
+    -------
+    np.ndarray
+        Integer labels per frame.
+    """
+
+    result = _cluster_microstates(
+        Y,
+        method=method,
+        n_states=n_states,
+        random_state=random_state,
+        **kwargs,
+    )
+    return result.labels
 
 
 def generate_free_energy_surface(
@@ -376,10 +404,33 @@ def analyze_msm(
     analysis_temperatures: Optional[List[float]] = None,
     use_effective_for_uncertainty: bool = True,
     use_tica: bool = True,
+    random_state: int = 42,
 ) -> Path:
     """Build and analyze an MSM, saving plots and artifacts.
 
-    Returns the analysis output directory.
+    Parameters
+    ----------
+    trajectory_files:
+        Trajectory file paths.
+    topology_pdb:
+        Topology in PDB format.
+    output_dir:
+        Destination directory.
+    feature_type:
+        Feature specification string.
+    analysis_temperatures:
+        Optional list of temperatures for analysis.
+    use_effective_for_uncertainty:
+        Whether to use effective counts for uncertainty.
+    use_tica:
+        Whether to apply TICA reduction.
+    random_state:
+        Seed for deterministic clustering.
+
+    Returns
+    -------
+    Path
+        The analysis output directory.
     """
     msm_out = Path(output_dir) / "msm_analysis"
 
@@ -388,6 +439,7 @@ def analyze_msm(
         topology_file=str(topology_pdb),
         temperatures=analysis_temperatures or [300.0],
         output_dir=str(msm_out),
+        random_state=random_state,
     )
     if use_effective_for_uncertainty:
         msm.count_mode = "sliding"
@@ -399,7 +451,7 @@ def analyze_msm(
 
     # Cluster
     N_CLUSTERS = 8
-    msm.cluster_features(n_clusters=int(N_CLUSTERS))
+    msm.cluster_features(n_states=int(N_CLUSTERS))
 
     # Method selection
     method = (
@@ -500,7 +552,7 @@ def find_conformations(
     specs = feature_specs if feature_specs is not None else ["phi_psi"]
     X, cols, periodic = compute_features(traj, feature_specs=specs)
     Y = reduce_features(X, method="vamp", lag=10, n_components=3)
-    labels = cluster_microstates(Y, method="minibatchkmeans", n_clusters=8)
+    labels = cluster_microstates(Y, method="minibatchkmeans", n_states=8)
 
     dtrajs = [labels]
     observed_states = int(np.max(labels)) + 1 if labels.size else 0

--- a/src/pmarlo/cluster/micro.py
+++ b/src/pmarlo/cluster/micro.py
@@ -1,30 +1,77 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Literal, cast
 
 import numpy as np
 from sklearn.cluster import KMeans, MiniBatchKMeans
+from sklearn.metrics import silhouette_score
+
+import logging
+
+logger = logging.getLogger("pmarlo")
+
+
+@dataclass
+class ClusteringResult:
+    """Result of microstate clustering."""
+
+    labels: np.ndarray
+    n_states: int
+    rationale: str | None = None
+    centers: np.ndarray | None = None
 
 
 def cluster_microstates(
     Y: np.ndarray,
-    method: Literal["minibatchkmeans", "kmeans"] = "minibatchkmeans",
-    n_clusters: int = 200,
+    method: Literal["minibatchkmeans", "kmeans"] = "kmeans",
+    n_states: int | Literal["auto"] = "auto",
     random_state: int = 42,
     **kwargs,
-) -> np.ndarray:
-    """Cluster reduced data into microstates and return labels."""
+) -> ClusteringResult:
+    """Cluster reduced data into microstates and return clustering result."""
+
     if Y.shape[0] == 0:
-        return np.zeros((0,), dtype=int)
+        return ClusteringResult(labels=np.zeros((0,), dtype=int), n_states=0)
     if Y.shape[1] == 0:
         raise ValueError("Input array must have at least one feature")
+
+    requested = n_states
+    rationale: str | None = None
+
+    if isinstance(n_states, str) and n_states == "auto":
+        candidates = range(4, 21)
+        scores: list[tuple[int, float]] = []
+        for n in candidates:
+            km = KMeans(n_clusters=n, random_state=random_state, n_init=10)
+            labels = km.fit_predict(Y)
+            if len(set(labels)) <= 1:
+                score = -1.0
+            else:
+                score = silhouette_score(Y, labels)
+            scores.append((n, float(score)))
+        chosen, best = max(scores, key=lambda x: x[1])
+        rationale = f"silhouette={best:.3f}"
+        n_states = chosen
+    else:
+        n_states = int(n_states)
+
     if method == "minibatchkmeans":
-        km = MiniBatchKMeans(n_clusters=n_clusters, random_state=random_state, **kwargs)
+        km = MiniBatchKMeans(n_clusters=n_states, random_state=random_state, **kwargs)
     elif method == "kmeans":
-        km = KMeans(
-            n_clusters=n_clusters, random_state=random_state, n_init=10, **kwargs
-        )
+        km = KMeans(n_clusters=n_states, random_state=random_state, n_init=10, **kwargs)
     else:
         raise ValueError(f"Unsupported clustering method: {method}")
-    labels = km.fit_predict(Y)
-    return cast(np.ndarray, labels.astype(int))
+
+    labels = cast(np.ndarray, km.fit_predict(Y).astype(int))
+    centers = getattr(km, "cluster_centers_", None)
+
+    logger.info(
+        "Clustering: requested=%s, actual=%d%s",
+        requested,
+        n_states,
+        f" ({rationale})" if rationale else "",
+    )
+    return ClusteringResult(
+        labels=labels, n_states=n_states, rationale=rationale, centers=centers
+    )

--- a/src/pmarlo/experiments/msm.py
+++ b/src/pmarlo/experiments/msm.py
@@ -55,7 +55,7 @@ def _perform_msm_analysis_with_tracking(config: MSMConfig, run_dir: Path):
             trajectory_files=config.trajectory_files,
             topology_file=config.topology_file,
             output_dir=str(run_dir / "msm"),
-            n_clusters=config.n_clusters,
+            n_states=config.n_clusters,
             lag_time=config.lag_time,
             feature_type=config.feature_type,
             temperatures=config.temperatures,

--- a/src/pmarlo/main.py
+++ b/src/pmarlo/main.py
@@ -43,6 +43,8 @@ import argparse
 import sys
 from pathlib import Path
 from typing import Any, Dict, Optional, cast
+import random
+import numpy as np
 
 BASE_DIR = Path(__file__).resolve().parent.parent
 TESTS_DIR = BASE_DIR / "tests" / "data"
@@ -394,6 +396,7 @@ Examples:
     _add_mode_argument(parser)
     _add_steps_argument(parser)
     _add_states_argument(parser)
+    _add_random_state_argument(parser)
     _add_id_argument(parser)
     _add_continue_argument(parser)
     _add_no_auto_continue_argument(parser)
@@ -434,6 +437,15 @@ def _add_states_argument(parser: argparse.ArgumentParser) -> None:
         type=int,
         default=50,
         help="Number of MSM states (default: 50)",
+    )
+
+
+def _add_random_state_argument(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--random-state",
+        type=int,
+        default=42,
+        help="Seed for random number generators",
     )
 
 
@@ -546,6 +558,8 @@ def main():
     args = _parse_args_or_default(parser)
     if _handle_list_runs_flag(args):
         return
+    random.seed(args.random_state)
+    np.random.seed(args.random_state)
     _print_program_header(args.mode)
     handlers = _get_mode_handlers()
     handler = handlers.get(args.mode)

--- a/src/pmarlo/pipeline.py
+++ b/src/pmarlo/pipeline.py
@@ -877,7 +877,7 @@ class LegacyPipeline:
             trajectory_files=trajectory_files,
             topology_file=str(pdb_fixed_path),
             output_dir=str(msm_output_dir),
-            n_clusters=n_states,
+            n_states=n_states,
             lag_time=10,
             feature_type="phi_psi",
             temperatures=analysis_temperatures,


### PR DESCRIPTION
## Summary
- add `n_states` parameter with optional automatic selection for microstate clustering
- propagate deterministic clustering and seed control through MSM pipeline and CLI
- test Gaussian blobs to ensure fixed and auto-picked cluster counts

## Testing
- `ruff check src/pmarlo/cluster/micro.py src/pmarlo/api.py src/pmarlo/markov_state_model/markov_state_model.py src/pmarlo/main.py src/pmarlo/experiments/msm.py src/pmarlo/pipeline.py example_programs/find_conformations_with_msm.py tests/test_cluster_micro.py`
- `black src/pmarlo/cluster/micro.py src/pmarlo/api.py src/pmarlo/markov_state_model/markov_state_model.py src/pmarlo/main.py tests/test_cluster_micro.py example_programs/find_conformations_with_msm.py src/pmarlo/experiments/msm.py src/pmarlo/pipeline.py`
- `mypy src/pmarlo/cluster/micro.py src/pmarlo/api.py src/pmarlo/markov_state_model/markov_state_model.py src/pmarlo/main.py src/pmarlo/experiments/msm.py src/pmarlo/pipeline.py example_programs/find_conformations_with_msm.py tests/test_cluster_micro.py` *(fails: Name "List" is not defined, returning Any values, incompatible types)*
- `PYTHONPATH=src pytest tests/test_cluster_micro.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa20edbe44832e88f46b2ffb86fab4