### PR TITLE
Improve reproducibility utilities and logging

### DIFF
--- a/src/pmarlo/__init__.py
+++ b/src/pmarlo/__init__.py
@@ -16,6 +16,7 @@ from .replica_exchange.replica_exchange import ReplicaExchange
 from .simulation.simulation import Simulation
 from .utils.msm_utils import candidate_lag_ladder
 from .utils.replica_utils import power_of_two_temperature_ladder
+from .utils.seed import set_global_seed
 
 __version__ = "0.1.0"
 __author__ = "PMARLO Development Team"
@@ -31,4 +32,5 @@ __all__ = [
     "LegacyPipeline",
     "power_of_two_temperature_ladder",
     "candidate_lag_ladder",
+    "set_global_seed",
 ]

--- a/src/pmarlo/cluster/micro.py
+++ b/src/pmarlo/cluster/micro.py
@@ -2,18 +2,29 @@ from __future__ import annotations
 
 from typing import Literal, cast
 
+import logging
 import numpy as np
 from sklearn.cluster import KMeans, MiniBatchKMeans
+
+logger = logging.getLogger("pmarlo")
 
 
 def cluster_microstates(
     Y: np.ndarray,
     method: Literal["minibatchkmeans", "kmeans"] = "minibatchkmeans",
     n_clusters: int = 200,
-    random_state: int = 42,
+    random_state: int | None = 42,
     **kwargs,
 ) -> np.ndarray:
-    """Cluster reduced data into microstates and return labels."""
+    """Cluster reduced data into microstates and return labels.
+
+    Args:
+        Y: Feature array of shape ``(n_samples, n_features)``.
+        method: Clustering algorithm to use.
+        n_clusters: Number of clusters to form.
+        random_state: Seed for the scikit-learn estimator. ``None`` uses
+            the library's global RNG state.
+    """
     if Y.shape[0] == 0:
         return np.zeros((0,), dtype=int)
     if Y.shape[1] == 0:

--- a/src/pmarlo/experiments/utils.py
+++ b/src/pmarlo/experiments/utils.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
 from datetime import datetime
-import random
 from pathlib import Path
 from typing import Union
 
-import numpy as np
+from ..utils.seed import set_global_seed
 
 
 def timestamp_dir(base_dir: Union[str, Path]) -> Path:
@@ -31,9 +30,8 @@ def tests_data_dir() -> Path:
 
 
 def set_seed(seed: int | None) -> None:
-    """Seed Python and NumPy RNGs for experiment reproducibility."""
+    """Seed RNGs for experiment reproducibility."""
 
     if seed is None:
         return
-    random.seed(int(seed))
-    np.random.seed(int(seed))
+    set_global_seed(int(seed))

--- a/src/pmarlo/markov_state_model/markov_state_model.py
+++ b/src/pmarlo/markov_state_model/markov_state_model.py
@@ -30,7 +30,7 @@ from scipy.ndimage import gaussian_filter
 from scipy.sparse import csc_matrix, issparse, save_npz
 from sklearn.cluster import MiniBatchKMeans
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("pmarlo")
 
 # Suppress warnings for cleaner output
 warnings.filterwarnings("ignore", category=FutureWarning)
@@ -462,13 +462,19 @@ class EnhancedMSM:
         if self.features is not None:
             logger.info(f"Features computed: {self.features.shape}")
 
-    def cluster_features(self, n_clusters: int = 100, algorithm: str = "kmeans"):
-        """
-        Cluster features to create discrete states.
+    def cluster_features(
+        self,
+        n_clusters: int = 100,
+        algorithm: str = "kmeans",
+        random_state: int | None = 42,
+    ) -> None:
+        """Cluster features to create discrete states.
 
         Args:
-            n_clusters: Number of clusters (states)
-            algorithm: Clustering algorithm ('kmeans', 'gmm')
+            n_clusters: Number of clusters (states).
+            algorithm: Clustering algorithm (currently only ``"kmeans"``).
+            random_state: Seed for the clustering estimator. ``None`` uses
+                scikit-learn's global RNG state.
         """
         logger.info(
             f"Clustering features into {n_clusters} states using {algorithm}..."
@@ -491,7 +497,9 @@ class EnhancedMSM:
             n_clusters = 10
 
         if algorithm == "kmeans":
-            clusterer = MiniBatchKMeans(n_clusters=n_clusters, random_state=42)
+            clusterer = MiniBatchKMeans(
+                n_clusters=n_clusters, random_state=random_state
+            )
             labels = clusterer.fit_predict(self.features)
             self.cluster_centers = clusterer.cluster_centers_
         else:

--- a/src/pmarlo/utils/seed.py
+++ b/src/pmarlo/utils/seed.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import logging
+import random
+
+import numpy as np
+
+try:
+    from sklearn.utils import check_random_state
+except Exception:  # pragma: no cover - sklearn optional
+    check_random_state = None  # type: ignore
+
+logger = logging.getLogger("pmarlo")
+
+
+def _quiet_external_loggers() -> None:
+    """Suppress noisy third-party loggers to INFO level."""
+    for name in ("openmm", "mdtraj", "dcdplugin"):
+        logging.getLogger(name).setLevel(logging.INFO)
+
+
+def set_global_seed(seed: int) -> np.random.Generator:
+    """Seed common RNGs for reproducible results.
+
+    This seeds :mod:`random` and :mod:`numpy.random` with ``seed`` and, when
+    available, initializes scikit-learn's global RNG state via
+    :func:`sklearn.utils.check_random_state`.  The returned
+    :class:`numpy.random.Generator` can be used for applications requiring a
+    dedicated generator.
+
+    Notes
+    -----
+    Molecular dynamics performed with OpenMM remain stochastic.  Where
+    supported, integrators should be seeded explicitly via ``setRandomSeed``.
+    """
+    seed = int(seed)
+    random.seed(seed)
+    np.random.seed(seed)
+    if check_random_state is not None:
+        check_random_state(seed)
+    else:  # pragma: no cover - optional dependency
+        logger.info("scikit-learn not available; skipping estimator seeding")
+    _quiet_external_loggers()
+    return np.random.default_rng(seed)

--- a/tests/test_global_seed.py
+++ b/tests/test_global_seed.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import numpy as np
+
+from pmarlo.cluster.micro import cluster_microstates
+from pmarlo.states.msm_bridge import _fit_msm_fallback
+from pmarlo.utils.seed import set_global_seed
+
+
+def _run(seed: int) -> tuple[np.ndarray, np.ndarray]:
+    set_global_seed(seed)
+    Y = np.random.rand(100, 3)
+    labels = cluster_microstates(Y, n_clusters=5, random_state=seed)
+    T, _ = _fit_msm_fallback([labels], n_states=5, lag=1)
+    return labels, T
+
+
+def test_reproducible_clustering_and_msm() -> None:
+    labels1, T1 = _run(123)
+    labels2, T2 = _run(123)
+    assert np.array_equal(labels1, labels2)
+    assert np.allclose(T1, T2)


### PR DESCRIPTION
## Summary
- add `set_global_seed` helper to seed NumPy, random, and sklearn and quiet common MD loggers
- allow passing `random_state` to major constructors and clustering helpers
- clean noisy prints and add regression test for deterministic microstate assignments and MSM transitions

## Testing
- `ruff check src/pmarlo/utils/seed.py src/pmarlo/cluster/micro.py src/pmarlo/states/msm_bridge.py src/pmarlo/markov_state_model/markov_state_model.py src/pmarlo/replica_exchange/replica_exchange.py src/pmarlo/simulation/simulation.py src/pmarlo/experiments/utils.py tests/test_global_seed.py`
- `black --check src/pmarlo/utils/seed.py src/pmarlo/cluster/micro.py src/pmarlo/states/msm_bridge.py src/pmarlo/markov_state_model/markov_state_model.py src/pmarlo/replica_exchange/replica_exchange.py src/pmarlo/simulation/simulation.py src/pmarlo/experiments/utils.py tests/test_global_seed.py`
- `mypy --follow-imports=skip tests/test_global_seed.py`
- `PYTHONPATH=src pytest tests/test_global_seed.py -q`
- `tox -q -e py312-no-pdbfixer` *(fails: data path assertions and XmlSerializer attribute)*

------
https://chatgpt.com/codex/tasks/task_e_68aa22543ddc832e9b016bba15d727a7