### PR TITLE
Stream trajectory loading and add adaptive clustering

### DIFF
--- a/src/pmarlo/experiments/cli.py
+++ b/src/pmarlo/experiments/cli.py
@@ -77,6 +77,12 @@ def main():
     msm.add_argument("--clusters", type=int, default=60)
     msm.add_argument("--lag", type=int, default=20)
     msm.add_argument("--out", default="experiments_output/msm")
+    msm.add_argument("--stride", type=int, default=1, help="Trajectory frame stride")
+    msm.add_argument(
+        "--atom-selection",
+        default=None,
+        help="MDTraj atom selection string to subset atoms",
+    )
 
     args = parser.parse_args()
 
@@ -120,6 +126,8 @@ def main():
             output_dir=args.out,
             n_clusters=args.clusters,
             lag_time=args.lag,
+            stride=args.stride,
+            atom_selection=args.atom_selection,
         )
         result = run_msm_experiment(cfg)
 

--- a/src/pmarlo/experiments/msm.py
+++ b/src/pmarlo/experiments/msm.py
@@ -40,6 +40,8 @@ class MSMConfig:
     lag_time: int = 20
     feature_type: str = "phi_psi"
     temperatures: List[float] | None = None
+    stride: int = 1
+    atom_selection: str | None = None
     seed: int | None = None
 
 
@@ -59,6 +61,8 @@ def _perform_msm_analysis_with_tracking(config: MSMConfig, run_dir: Path):
             lag_time=config.lag_time,
             feature_type=config.feature_type,
             temperatures=config.temperatures,
+            stride=config.stride,
+            atom_selection=config.atom_selection,
         )
     return msm, tracker
 

--- a/tests/test_cluster_micro.py
+++ b/tests/test_cluster_micro.py
@@ -37,3 +37,11 @@ def test_auto_and_fixed_states():
     auto = cluster_microstates(X, n_states="auto", random_state=0)
     assert 4 <= auto.n_states <= 20
     assert auto.rationale is not None
+
+
+def test_auto_switches_to_minibatch():
+    Y = np.random.rand(10, 10)
+    with patch("pmarlo.cluster.micro.MiniBatchKMeans") as mock_mb:
+        mock_mb.return_value.fit_predict.return_value = np.zeros(10, dtype=int)
+        cluster_microstates(Y, method="auto", n_states=2, minibatch_threshold=50)
+        assert mock_mb.called

--- a/tests/test_iterload_stream.py
+++ b/tests/test_iterload_stream.py
@@ -1,0 +1,15 @@
+import logging
+from pathlib import Path
+
+from pmarlo.markov_state_model.markov_state_model import EnhancedMSM
+
+
+def test_iterload_streaming(caplog):
+    traj = Path("tests/data/traj.dcd")
+    pdb = Path("tests/data/3gd8-fixed.pdb")
+    msm = EnhancedMSM([str(traj)], topology_file=str(pdb))
+    with caplog.at_level(logging.INFO):
+        msm.load_trajectories(stride=2, atom_selection="name CA", chunk_size=5)
+    assert msm.trajectories and msm.trajectories[0].n_frames == 50
+    assert msm.trajectories[0].n_atoms < 500  # reduced atom count
+    assert any("Streaming trajectory" in rec.getMessage() for rec in caplog.records)


### PR DESCRIPTION
## Summary
- Stream DCD trajectories via `mdtraj.iterload` with stride and atom-selection controls
- Auto-switch to MiniBatchKMeans for large datasets to avoid OOM during clustering
- Expose streaming options via CLI and add unit tests for iterload path

## Testing
- `ruff check src/pmarlo/cluster/micro.py src/pmarlo/markov_state_model/markov_state_model.py src/pmarlo/api.py src/pmarlo/experiments/msm.py src/pmarlo/experiments/cli.py tests/test_cluster_micro.py tests/test_iterload_stream.py`
- `black src/pmarlo/cluster/micro.py src/pmarlo/markov_state_model/markov_state_model.py src/pmarlo/api.py src/pmarlo/experiments/msm.py src/pmarlo/experiments/cli.py tests/test_cluster_micro.py tests/test_iterload_stream.py`
- `mypy src/pmarlo > /tmp/mypy.log && tail -n 20 /tmp/mypy.log`
- `pytest > /tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68aa2cc5ac1c832eadb35224ac42d83c