### PR TITLE
feat: add global seed utilities for deterministic runs

### DIFF
--- a/src/pmarlo/__init__.py
+++ b/src/pmarlo/__init__.py
@@ -16,6 +16,7 @@ from .replica_exchange.replica_exchange import ReplicaExchange
 from .simulation.simulation import Simulation
 from .utils.msm_utils import candidate_lag_ladder
 from .utils.replica_utils import power_of_two_temperature_ladder
+from .utils.seed import quiet_external_loggers
 
 __version__ = "0.1.0"
 __author__ = "PMARLO Development Team"
@@ -32,3 +33,6 @@ __all__ = [
     "power_of_two_temperature_ladder",
     "candidate_lag_ladder",
 ]
+
+# Reduce noise from third-party libraries upon import
+quiet_external_loggers()

--- a/src/pmarlo/api.py
+++ b/src/pmarlo/api.py
@@ -103,7 +103,7 @@ def cluster_microstates(
     Y: np.ndarray,
     method: Literal["auto", "minibatchkmeans", "kmeans"] = "auto",
     n_states: int | Literal["auto"] = "auto",
-    random_state: int = 42,
+    random_state: int | None = 42,
     minibatch_threshold: int = 5_000_000,
     **kwargs,
 ) -> np.ndarray:
@@ -120,7 +120,8 @@ def cluster_microstates(
     n_states:
         Number of states or ``"auto"`` to select via silhouette.
     random_state:
-        Seed for deterministic clustering.
+        Seed for deterministic clustering.  When ``None`` the global NumPy
+        random state is used.
     minibatch_threshold:
         Product of frames and features above which ``MiniBatchKMeans`` is used
         when ``method="auto"``.
@@ -437,7 +438,7 @@ def analyze_msm(
     analysis_temperatures: Optional[List[float]] = None,
     use_effective_for_uncertainty: bool = True,
     use_tica: bool = True,
-    random_state: int = 42,
+    random_state: int | None = 42,
     traj_stride: int = 1,
     atom_selection: str | Sequence[int] | None = None,
     chunk_size: int = 1000,
@@ -461,7 +462,7 @@ def analyze_msm(
     use_tica:
         Whether to apply TICA reduction.
     random_state:
-        Seed for deterministic clustering.
+        Seed for deterministic clustering. ``None`` uses the global state.
     traj_stride:
         Stride for loading trajectory frames.
     atom_selection:

--- a/src/pmarlo/cluster/micro.py
+++ b/src/pmarlo/cluster/micro.py
@@ -34,7 +34,7 @@ def cluster_microstates(
     Y: np.ndarray,
     method: Literal["auto", "minibatchkmeans", "kmeans"] = "auto",
     n_states: int | Literal["auto"] = "auto",
-    random_state: int = 42,
+    random_state: int | None = 42,
     minibatch_threshold: int = 5_000_000,
     **kwargs,
 ) -> ClusteringResult:
@@ -52,7 +52,8 @@ def cluster_microstates(
         Number of microstates to identify or ``"auto"`` to select the number
         based on the silhouette score.
     random_state:
-        Seed for deterministic clustering.
+        Seed for deterministic clustering.  When ``None`` the global NumPy
+        random state is used.
     minibatch_threshold:
         Product of frames and features above which ``MiniBatchKMeans`` is used
         when ``method="auto"``.

--- a/src/pmarlo/pipeline.py
+++ b/src/pmarlo/pipeline.py
@@ -21,6 +21,7 @@ from .protein.protein import Protein
 from .replica_exchange.config import RemdConfig
 from .replica_exchange.replica_exchange import ReplicaExchange, run_remd_simulation
 from .simulation.simulation import Simulation
+from .utils.seed import set_global_seed
 
 logger = logging.getLogger(__name__)
 
@@ -46,6 +47,7 @@ class Pipeline:
         checkpoint_id: Optional[str] = None,
         auto_continue: bool = True,
         enable_checkpoints: bool = True,
+        random_state: int | None = None,
     ):
         """
         Initialize the PMARLO pipeline.
@@ -60,6 +62,7 @@ class Pipeline:
             use_replica_exchange: Whether to use replica exchange
             use_metadynamics: Whether to use metadynamics
             checkpoint_id: Optional checkpoint ID for resuming runs
+            random_state: Seed for reproducible behaviour across components.
         """
         self.pdb_file = pdb_file
         self.output_dir = Path(output_dir)
@@ -67,6 +70,10 @@ class Pipeline:
         self.n_states = n_states
         self.use_replica_exchange = use_replica_exchange
         self.use_metadynamics = use_metadynamics
+        self.random_state = random_state
+
+        if random_state is not None:
+            set_global_seed(int(random_state))
 
         # Set default temperatures if not provided
         if temperatures is None:

--- a/src/pmarlo/protein/protein.py
+++ b/src/pmarlo/protein/protein.py
@@ -29,6 +29,7 @@ class Protein:
         ph: float = 7.0,
         auto_prepare: bool = True,
         preparation_options: Optional[Dict[str, Any]] = None,
+        random_state: int | None = None,
     ):
         """Initialize a Protein object with a PDB file.
 
@@ -37,6 +38,7 @@ class Protein:
             ph: pH value for protonation state (default: 7.0)
             auto_prepare: Automatically prepare the protein (default: True)
             preparation_options: Custom preparation options
+            random_state: Included for API compatibility; currently unused.
 
         Raises:
             ValueError: If the PDB file does not exist, is empty, or has an invalid
@@ -51,6 +53,7 @@ class Protein:
             )
 
         pdb_path = self._resolve_pdb_path(pdb_file)
+        self.random_state = random_state
         self._validate_file_exists(pdb_path)
         self._validate_extension(pdb_path)
         self._validate_readable_nonempty(pdb_path)
@@ -147,7 +150,9 @@ class Protein:
                 coords = pos.value_in_unit(unit.nanometer)
             except Exception as exc:  # pragma: no cover - defensive
                 raise ValueError(f"Invalid coordinate for atom {i}: {exc}") from exc
-            if any(math.isnan(c) or math.isinf(c) for c in (coords.x, coords.y, coords.z)):
+            if any(
+                math.isnan(c) or math.isinf(c) for c in (coords.x, coords.y, coords.z)
+            ):
                 raise ValueError(f"Atom {i} has non-finite coordinates")
 
     def _assign_basic_fields(self, pdb_path: Path, ph: float) -> None:

--- a/src/pmarlo/states/msm_bridge.py
+++ b/src/pmarlo/states/msm_bridge.py
@@ -144,10 +144,23 @@ def _stationary_from_T(T: np.ndarray) -> np.ndarray:
 
 
 def pcca_like_macrostates(
-    T: np.ndarray, n_macrostates: int = 4, random_state: int = 42
+    T: np.ndarray, n_macrostates: int = 4, random_state: int | None = 42
 ) -> Optional[np.ndarray]:
-    """Compute metastable sets using PCCA+ (deeptime), fallback to k-means on eigenvectors.
-    Returns hard labels per microstate.
+    """Compute metastable sets using PCCA+ with a k-means fallback.
+
+    Parameters
+    ----------
+    T:
+        Microstate transition matrix.
+    n_macrostates:
+        Desired number of macrostates.
+    random_state:
+        Seed for the k-means fallback. ``None`` uses NumPy's global state.
+
+    Returns
+    -------
+    Optional[np.ndarray]
+        Hard labels per microstate or ``None`` if the decomposition failed.
     """
     if T.size == 0 or T.shape[0] <= n_macrostates:
         return None

--- a/src/pmarlo/utils/seed.py
+++ b/src/pmarlo/utils/seed.py
@@ -1,0 +1,75 @@
+"""Randomness and logging utilities for reproducible PMARLO runs.
+
+This module provides helpers to seed global random number generators and
+silence verbose third-party libraries. Deterministic behaviour is
+critical for scientific workflows, hence these utilities centralise the
+configuration in one location.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import logging
+import random
+from typing import Iterator
+
+import numpy as np
+from sklearn.utils import check_random_state
+
+logger = logging.getLogger("pmarlo")
+
+
+def set_global_seed(seed: int) -> None:
+    """Seed common RNG sources for deterministic behaviour.
+
+    Parameters
+    ----------
+    seed:
+        The integer seed to apply globally.
+
+    Notes
+    -----
+    This function seeds Python's :mod:`random` module, NumPy's legacy
+    ``numpy.random`` module and initialises scikit-learn's RNG via
+    :func:`sklearn.utils.check_random_state`.
+
+    Molecular dynamics in OpenMM remain stochastic as integrators often
+    have their own random streams. If the integrator exposes a
+    ``setRandomNumberSeed`` method it should be seeded separately.
+    """
+
+    random.seed(seed)
+    np.random.seed(seed)
+    # Initialise scikit-learn's global RNG helper
+    check_random_state(seed)
+    logger.info("Global seed set to %d", seed)
+
+
+def quiet_external_loggers(level: int = logging.INFO) -> None:
+    """Reduce stdout noise from verbose third-party libraries.
+
+    Parameters
+    ----------
+    level:
+        Log level to apply to known noisy loggers.
+    """
+
+    for name in ("openmm", "mdtraj", "dcdplugin"):
+        logging.getLogger(name).setLevel(level)
+
+    # Import mdtraj quietly to silence its plugin banner (e.g. dcdplugin)
+    with _suppress_stdout():
+        try:  # pragma: no cover - import side effect
+            import mdtraj  # type: ignore  # noqa: F401
+        except Exception:
+            pass
+
+
+@contextlib.contextmanager
+def _suppress_stdout() -> Iterator[None]:
+    """Context manager that redirects ``stdout`` to silence plugin banners."""
+
+    old_stdout = io.StringIO()
+    with contextlib.redirect_stdout(old_stdout):
+        yield

--- a/tests/test_seed_reproducibility.py
+++ b/tests/test_seed_reproducibility.py
@@ -1,0 +1,32 @@
+import numpy as np
+from sklearn.datasets import make_blobs
+
+from pmarlo.cluster.micro import cluster_microstates
+from pmarlo.markov_state_model.markov_state_model import EnhancedMSM
+from pmarlo.utils.seed import set_global_seed
+
+
+def _transition_from_labels(labels: np.ndarray, out_dir: str) -> np.ndarray:
+    """Build a transition matrix for testing purposes."""
+    msm = EnhancedMSM(random_state=None, output_dir=out_dir)
+    msm.n_states = int(labels.max()) + 1 if labels.size else 0
+    msm.dtrajs = [labels]
+    msm._build_standard_msm(lag_time=1)
+    assert msm.transition_matrix is not None
+    return np.asarray(msm.transition_matrix, dtype=float)
+
+
+def test_reproducible_clustering_and_msm(tmp_path):
+    """Two runs with the same seed should be identical."""
+    data, _ = make_blobs(n_samples=200, centers=4, n_features=2, random_state=0)
+
+    set_global_seed(123)
+    res1 = cluster_microstates(data, n_states=4, random_state=None)
+    T1 = _transition_from_labels(res1.labels, str(tmp_path / "run1"))
+
+    set_global_seed(123)
+    res2 = cluster_microstates(data, n_states=4, random_state=None)
+    T2 = _transition_from_labels(res2.labels, str(tmp_path / "run2"))
+
+    assert np.array_equal(res1.labels, res2.labels)
+    assert np.allclose(T1, T2)


### PR DESCRIPTION
## Summary
- add `set_global_seed` helper and quiet third-party loggers
- allow optional `random_state` in constructors and seed pipeline runs
- test reproducible clustering and Markov state modeling

## Testing
- `ruff check src/pmarlo/utils/seed.py src/pmarlo/__init__.py src/pmarlo/cluster/micro.py src/pmarlo/markov_state_model/markov_state_model.py src/pmarlo/replica_exchange/replica_exchange.py src/pmarlo/simulation/simulation.py src/pmarlo/pipeline.py src/pmarlo/protein/protein.py src/pmarlo/states/msm_bridge.py src/pmarlo/api.py tests/test_seed_reproducibility.py`
- `tox -e type`
- `PYTHONPATH=src pytest tests/test_seed_reproducibility.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa2f088240832eb7b66fbebc6638b5