### PR TITLE
feat: add Bayesian ITS with plateau detection

### DIFF
--- a/src/pmarlo/results.py
+++ b/src/pmarlo/results.py
@@ -164,3 +164,17 @@ class CKResult(BaseResult):
 
     lag_times: np.ndarray
     timescales: np.ndarray
+
+
+@dataclass
+class ITSResult(BaseResult):
+    """Implied timescale estimation results with confidence intervals."""
+
+    lag_times: np.ndarray
+    eigenvalues: np.ndarray
+    eigenvalues_ci: np.ndarray
+    timescales: np.ndarray
+    timescales_ci: np.ndarray
+    rates: np.ndarray
+    rates_ci: np.ndarray
+    recommended_lag_window: Optional[tuple[int, int]] = None

--- a/tests/integration/replica_exchange/test_demux_metadata.py
+++ b/tests/integration/replica_exchange/test_demux_metadata.py
@@ -7,6 +7,7 @@ import numpy as np
 from pmarlo.markov_state_model.markov_state_model import EnhancedMSM
 from pmarlo.replica_exchange.demux_metadata import DemuxMetadata
 from pmarlo.replica_exchange.replica_exchange import ReplicaExchange
+from pmarlo.results import ITSResult
 
 matplotlib.use("Agg")
 
@@ -67,7 +68,16 @@ def test_demux_metadata_roundtrip(tmp_path):
         / meta.frames_per_segment,
     )
 
-    msm.implied_timescales = {"lag_times": [1], "timescales": np.array([[1.0]])}
+    msm.implied_timescales = ITSResult(
+        lag_times=np.array([1]),
+        eigenvalues=np.array([[0.5]]),
+        eigenvalues_ci=np.array([[[0.4, 0.6]]]),
+        timescales=np.array([[1.0]]),
+        timescales_ci=np.array([[[0.8, 1.2]]]),
+        rates=np.array([[1.0]]),
+        rates_ci=np.array([[[0.8, 1.2]]]),
+        recommended_lag_window=(1, 1),
+    )
     msm.plot_implied_timescales()
     xlabel = matplotlib.pyplot.gca().get_xlabel()
     assert "ps" in xlabel or "ns" in xlabel

--- a/tests/unit/markov_state_model/test_its_plateau.py
+++ b/tests/unit/markov_state_model/test_its_plateau.py
@@ -1,0 +1,39 @@
+import numpy as np
+
+from pmarlo.markov_state_model.markov_state_model import EnhancedMSM
+
+
+def test_plateau_detection_recovers_known_timescale():
+    rng = np.random.default_rng(0)
+    # Symmetric two-state MSM with p=0.05 transition probability
+    T = np.array([[0.95, 0.05], [0.05, 0.95]])
+    n_steps = 10000
+    states = np.zeros(n_steps, dtype=int)
+    for i in range(1, n_steps):
+        states[i] = rng.choice(2, p=T[states[i - 1]])
+
+    msm = EnhancedMSM(output_dir=".")
+    msm.dtrajs = [states]
+    msm.n_states = 2
+    msm.count_mode = "sliding"
+    msm.build_msm(lag_time=1)
+    msm.compute_implied_timescales(
+        lag_times=[1, 2, 5, 10, 20, 30],
+        n_timescales=1,
+        n_samples=50,
+        plateau_m=1,
+        plateau_epsilon=0.2,
+    )
+    res = msm.implied_timescales
+    assert res is not None
+    assert res.recommended_lag_window is not None
+    start, end = res.recommended_lag_window
+    lags = res.lag_times
+    mask = (lags >= start) & (lags <= end)
+    ts = res.timescales[mask, 0]
+    assert np.nanmax(ts) - np.nanmin(ts) <= 0.1 * np.nanmean(ts)
+    # theoretical timescale for p=0.05
+    t_true = -1.0 / np.log(0.9)
+    assert abs(np.nanmean(ts) - t_true) / t_true < 0.2
+    # rates should not collapse to zero
+    assert res.rates[mask][-1] > 0.01

--- a/tests/unit/markov_state_model/test_markov_state_model.py
+++ b/tests/unit/markov_state_model/test_markov_state_model.py
@@ -56,14 +56,18 @@ def test_implied_timescales_lag_cap():
     dtraj = [0, 1, 0, 1, 0, 1]
     msm = _build_simple_msm(dtraj, lag_time=1, mode="sliding")
     msm.compute_implied_timescales(lag_times=[1, 300], n_timescales=2)
-    lags = msm.implied_timescales["lag_times"]
+    res = msm.implied_timescales
+    assert res is not None
+    lags = list(res.lag_times)
     assert all(lag_val <= 5 for lag_val in lags)
-    assert msm.implied_timescales["timescales"].shape[0] == len(lags)
+    assert res.timescales.shape[0] == len(lags)
 
 
 def test_implied_timescales_no_valid_lag():
     dtraj = [0, 1]
     msm = _build_simple_msm(dtraj, lag_time=1, mode="sliding")
     msm.compute_implied_timescales(lag_times=[5, 10], n_timescales=2)
-    assert msm.implied_timescales["lag_times"] == []
-    assert msm.implied_timescales["timescales"].size == 0
+    res = msm.implied_timescales
+    assert res is not None
+    assert res.lag_times.size == 0
+    assert res.timescales.size == 0


### PR DESCRIPTION
## Summary
- add `ITSResult` dataclass for implied timescale analysis
- compute implied timescales via Bayesian sampling with confidence intervals and automatic plateau detection
- plot implied rates alongside timescales with CI bands

## Testing
- `ruff check src/pmarlo/results.py src/pmarlo/markov_state_model/markov_state_model.py tests/unit/markov_state_model/test_markov_state_model.py tests/unit/markov_state_model/test_its_plateau.py tests/integration/replica_exchange/test_demux_metadata.py`
- `black src/pmarlo/results.py src/pmarlo/markov_state_model/markov_state_model.py tests/unit/markov_state_model/test_markov_state_model.py tests/unit/markov_state_model/test_its_plateau.py tests/integration/replica_exchange/test_demux_metadata.py`
- `mypy src/pmarlo/results.py src/pmarlo/markov_state_model/markov_state_model.py` *(fails: Returning Any from function declared to return ndarray)*
- `PYTHONPATH=src pytest tests/unit/markov_state_model/test_markov_state_model.py tests/unit/markov_state_model/test_its_plateau.py tests/integration/replica_exchange/test_demux_metadata.py -q`
- `tox -q -e py312-no-pdbfixer -- tests/unit/markov_state_model/test_markov_state_model.py tests/unit/markov_state_model/test_its_plateau.py tests/integration/replica_exchange/test_demux_metadata.py` *(fails: KeyboardInterrupt during environment run)*

------
https://chatgpt.com/codex/tasks/task_e_68aa31670828832e92baef9583935996