### PR TITLE
Silence mdtraj DCD plugin chatter

### DIFF
--- a/src/pmarlo/api.py
+++ b/src/pmarlo/api.py
@@ -635,7 +635,9 @@ def find_conformations(
         f", selection={atom_selection}" if atom_selection else "",
     )
     traj: md.Trajectory | None = None
-    for chunk in md.iterload(
+    from pmarlo.io import trajectory as traj_io
+
+    for chunk in traj_io.iterload(
         str(trajectory_choice),
         top=str(topology_pdb),
         stride=traj_stride,

--- a/src/pmarlo/io/__init__.py
+++ b/src/pmarlo/io/__init__.py
@@ -1,0 +1,9 @@
+"""Input/output utilities and configuration for PMARLO."""
+
+# Whether to emit verbose messages from external trajectory plugins.
+# Users may toggle this at runtime to inspect plugin-level diagnostics.
+# By default, the VMD/MDTraj DCD plugin chatter is silenced to keep logs
+# focused on PMARLO's own output.
+verbose_plugin_logs: bool = False
+
+__all__ = ["verbose_plugin_logs"]

--- a/src/pmarlo/io/trajectory.py
+++ b/src/pmarlo/io/trajectory.py
@@ -1,0 +1,129 @@
+"""Trajectory I/O helpers with quiet plugin logging.
+
+This module wraps :mod:`mdtraj` trajectory loaders to silence the noisy
+VMD DCD plugin that prints diagnostic information directly to stdout.
+Users can opt into verbose plugin logs by setting
+:data:`pmarlo.io.verbose_plugin_logs` to ``True``.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import os
+import sys
+from typing import Iterator, Sequence
+
+from . import verbose_plugin_logs
+
+if verbose_plugin_logs:
+    import mdtraj as md  # type: ignore
+else:  # pragma: no cover - import side effect only
+    with open(os.devnull, "w") as devnull:
+        fd_out, fd_err = os.dup(1), os.dup(2)
+        os.dup2(devnull.fileno(), 1)
+        os.dup2(devnull.fileno(), 2)
+        try:
+            import mdtraj as md  # type: ignore
+        finally:
+            os.dup2(fd_out, 1)
+            os.dup2(fd_err, 2)
+            os.close(fd_out)
+            os.close(fd_err)
+
+_LOGGERS = ["mdtraj.formats.registry", "mdtraj.formats.dcd"]
+
+
+@contextlib.contextmanager
+def _suppress_plugin_output() -> Iterator[None]:
+    """Temporarily silence mdtraj's DCD plugin noise.
+
+    This redirects C-level prints to ``stdout``/``stderr`` and downgrades
+    the relevant Python loggers to ``WARNING`` for the duration of the
+    context, restoring previous levels afterwards.
+    """
+
+    if verbose_plugin_logs:
+        # Nothing to do; yield control immediately.
+        yield
+        return
+
+    # Store previous logger levels to restore later
+    prev_levels = {}
+    for name in _LOGGERS:
+        logger = logging.getLogger(name)
+        prev_levels[name] = logger.level
+        logger.setLevel(logging.WARNING)
+
+    # Redirect low-level file descriptors to devnull to silence C prints
+    with open(os.devnull, "w") as devnull:
+        fd_out, fd_err = os.dup(1), os.dup(2)
+        try:
+            sys.stdout.flush()
+            sys.stderr.flush()
+        except Exception:  # pragma: no cover
+            pass
+        os.dup2(devnull.fileno(), 1)
+        os.dup2(devnull.fileno(), 2)
+        try:
+            yield
+        finally:
+            try:
+                sys.stdout.flush()
+                sys.stderr.flush()
+            except Exception:  # pragma: no cover
+                pass
+            os.dup2(fd_out, 1)
+            os.dup2(fd_err, 2)
+            os.close(fd_out)
+            os.close(fd_err)
+            for name, level in prev_levels.items():
+                logging.getLogger(name).setLevel(level)
+
+
+def iterload(
+    filename: str,
+    *,
+    top: str | md.Trajectory | None = None,
+    stride: int = 1,
+    atom_indices: Sequence[int] | None = None,
+    chunk: int = 1000,
+) -> Iterator[md.Trajectory]:
+    """Stream trajectory frames quietly from disk.
+
+    Parameters
+    ----------
+    filename:
+        Path to the trajectory file (e.g. DCD).
+    top:
+        Topology information required by :func:`md.iterload`.
+    stride:
+        Only return every ``stride``-th frame.
+    atom_indices:
+        Optional subset of atoms to load.
+    chunk:
+        Number of frames to yield per iteration.
+    """
+
+    gen = md.iterload(
+        filename,
+        top=top,
+        stride=stride,
+        atom_indices=atom_indices,
+        chunk=chunk,
+    )
+
+    if verbose_plugin_logs:
+        try:
+            for chunk_traj in gen:
+                yield chunk_traj
+        finally:
+            gen.close()
+        return
+
+    with _suppress_plugin_output():
+        try:
+            for chunk_traj in gen:
+                yield chunk_traj
+        finally:
+            gen.close()

--- a/src/pmarlo/markov_state_model/markov_state_model.py
+++ b/src/pmarlo/markov_state_model/markov_state_model.py
@@ -217,7 +217,9 @@ class EnhancedMSM:
                 f", selection={atom_selection}" if atom_selection else "",
             )
             joined: md.Trajectory | None = None
-            for chunk in md.iterload(
+            from pmarlo.io import trajectory as traj_io
+
+            for chunk in traj_io.iterload(
                 traj_file,
                 top=self.topology_file,
                 stride=stride,

--- a/tests/test_io_logging.py
+++ b/tests/test_io_logging.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import io
+from contextlib import redirect_stdout
+from pathlib import Path
+
+from pmarlo.io import trajectory
+
+
+def test_dcd_plugin_quiet_by_default():
+    """Ensure noisy dcdplugin messages do not reach stdout."""
+
+    traj = Path("tests/data/traj.dcd")
+    pdb = Path("tests/data/3gd8-fixed.pdb")
+
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        # Only need to trigger a single chunk to reproduce the banner
+        for _ in trajectory.iterload(str(traj), top=str(pdb), chunk=5):
+            break
+    out = buf.getvalue().splitlines()
+    assert not any(line.startswith("dcdplugin)") for line in out)


### PR DESCRIPTION
## Summary
- add `verbose_plugin_logs` config to control trajectory plugin verbosity
- wrap mdtraj iterload to redirect dcdplugin output away from stdout
- stream trajectories through new quiet loader
- test that dcdplugin chatter is suppressed by default

## Testing
- `PYTHONPATH=src pytest tests/test_io_logging.py`
- `PYTHONPATH=src pytest` *(fails: ImportError: PDBFixer is required; ModuleNotFoundError: No module named 'deeptime')*
- `tox -e py311` *(skipped: could not find python interpreter with spec(s): python3.11)*
- `tox -e lint` *(fails: C901 complexity and unused imports)*
- `tox -e type`


------
https://chatgpt.com/codex/tasks/task_e_68aad0ea4ca0832ea93d2ddc62363ef4