### PR TITLE
Add strict MSM transition matrix validation

### DIFF
--- a/src/pmarlo/states/msm_bridge.py
+++ b/src/pmarlo/states/msm_bridge.py
@@ -6,7 +6,7 @@ from typing import Any, List, Optional, Tuple, cast
 import json
 import numpy as np
 
-from pmarlo.utils.msm_utils import ensure_connected_counts
+from pmarlo.utils.msm_utils import check_transition_matrix, ensure_connected_counts
 
 logger = logging.getLogger("pmarlo")
 
@@ -36,6 +36,7 @@ def build_simple_msm(
         T, pi = _fit_msm_fallback(dtrajs, n_states, lag, count_mode)
     logger.info(f"build_simple_msm: Transition matrix shape: {T.shape}")
     logger.info(f"build_simple_msm: Stationary distribution shape: {pi.shape}")
+    check_transition_matrix(T, pi)
     return T, pi
 
 

--- a/src/pmarlo/utils/msm_utils.py
+++ b/src/pmarlo/utils/msm_utils.py
@@ -148,3 +148,76 @@ def ensure_connected_counts(
     C_active = C[np.ix_(active, active)].astype(float)
     C_active += float(alpha)
     return ConnectedCountResult(C_active, active)
+
+
+def check_transition_matrix(
+    T: np.ndarray,
+    pi: np.ndarray,
+    *,
+    row_tol: float = 1e-12,
+    stat_tol: float = 1e-8,
+) -> None:
+    """Validate a transition matrix and stationary distribution.
+
+    The following conditions are enforced:
+
+    * Each row of ``T`` sums to 1 within ``row_tol``.
+    * All elements of ``T`` are non-negative.
+    * The provided ``pi`` is a left eigenvector of ``T`` with unit eigenvalue
+      up to ``stat_tol`` in the infinity norm.
+
+    Parameters
+    ----------
+    T:
+        Transition matrix.
+    pi:
+        Stationary distribution corresponding to ``T``.
+    row_tol:
+        Permitted deviation from exact row stochasticity.
+    stat_tol:
+        Permitted deviation of ``pi`` from the left eigenvector equation.
+
+    Raises
+    ------
+    ValueError
+        If any of the checks fail. The error message includes the offending
+        state indices to ease debugging.
+    """
+
+    if T.ndim != 2 or T.shape[0] != T.shape[1]:
+        raise ValueError("transition matrix must be square")
+    if pi.shape != (T.shape[0],):
+        raise ValueError("stationary distribution size mismatch")
+    if T.size == 0:
+        return
+
+    rowsum = T.sum(axis=1)
+    row_err = np.abs(rowsum - 1.0)
+    neg_idx = np.where(T < 0)
+    if neg_idx[0].size:
+        pairs = list(zip(neg_idx[0].tolist(), neg_idx[1].tolist()))
+        vals = T[neg_idx].tolist()
+        raise ValueError(f"Negative probabilities at {pairs}: {vals}")
+
+    bad_rows = np.where(row_err > row_tol)[0]
+    if bad_rows.size:
+        devs = row_err[bad_rows].tolist()
+        raise ValueError(
+            f"Non-stochastic rows at indices {bad_rows.tolist()}: {devs}"
+        )
+
+    pi_res = np.abs(pi @ T - pi)
+    max_err = float(np.max(pi_res)) if pi_res.size else 0.0
+    if max_err > stat_tol:
+        idx = int(np.argmax(pi_res))
+        raise ValueError(
+            f"Stationary distribution mismatch at state {idx} with error {max_err}"
+        )
+
+    min_entry = T.min(axis=1)
+    lines = ["state row_err min_T pi_res"]
+    for i in range(T.shape[0]):
+        lines.append(
+            f"{i:5d} {row_err[i]:.2e} {min_entry[i]:.2e} {pi_res[i]:.2e}"
+        )
+    logger.debug("MSM diagnostics:\n%s", "\n".join(lines))

--- a/tests/unit/utils/test_msm_checks.py
+++ b/tests/unit/utils/test_msm_checks.py
@@ -1,0 +1,35 @@
+import numpy as np
+import pytest
+
+from pmarlo.utils.msm_utils import check_transition_matrix
+from pmarlo.states.msm_bridge import _stationary_from_T
+
+
+def _random_stochastic_matrix(rng: np.random.Generator, n: int) -> np.ndarray:
+    T = rng.random((n, n))
+    T /= T.sum(axis=1, keepdims=True)
+    return T
+
+
+def test_check_transition_matrix_passes():
+    rng = np.random.default_rng(0)
+    T = _random_stochastic_matrix(rng, 5)
+    pi = _stationary_from_T(T)
+    check_transition_matrix(T, pi)
+
+
+def test_check_transition_matrix_catches_tiny_negative():
+    rng = np.random.default_rng(1)
+    for _ in range(5):
+        n = int(rng.integers(2, 6))
+        T = _random_stochastic_matrix(rng, n)
+        pi = _stationary_from_T(T)
+        check_transition_matrix(T, pi)  # baseline
+        i = int(rng.integers(0, n))
+        j = int(rng.integers(0, n))
+        eps = 1e-13
+        original = T[i, j]
+        T[i, j] = -eps
+        T[i, (j + 1) % n] += original + eps
+        with pytest.raises(ValueError, match="Negative probabilities"):
+            check_transition_matrix(T, pi)


### PR DESCRIPTION
## Summary
- add `check_transition_matrix` utility that enforces row-stochasticity, non-negativity, and stationary distribution accuracy
- run the check during MSM construction and log per-state diagnostics
- cover checker with fuzz tests that inject small negative entries

## Testing
- `PYTHONPATH=src pytest tests/unit/utils/test_msm_checks.py -q`
- `PYTHONPATH=src pytest tests/unit/markov_state_model/test_markov_state_model.py -q` *(fails: ModuleNotFoundError: No module named 'deeptime')*
- `tox -e py311-no-pdbfixer` *(skipped: could not find python interpreter with spec(s): python3.11)*

------
https://chatgpt.com/codex/tasks/task_e_68aae29ff494832ead04e72338e26e04