### PR TITLE
Add CK-based τ selection

### DIFF
--- a/tests/test_ck_tau_selection.py
+++ b/tests/test_ck_tau_selection.py
@@ -1,0 +1,26 @@
+import numpy as np
+from pathlib import Path
+
+from pmarlo.markov_state_model.markov_state_model import EnhancedMSM
+
+
+def _pattern_traj(repeats: int = 500) -> np.ndarray:
+    pattern = [0, 0, 1, 1]
+    return np.array(pattern * repeats, dtype=int)
+
+
+def test_ck_tau_selection(tmp_path: Path, capsys):
+    traj = _pattern_traj()
+    msm = EnhancedMSM(output_dir=str(tmp_path))
+    msm.dtrajs = [traj]
+    msm.n_states = 2
+    selected = msm.select_lag_time_ck([1, 2, 3])
+    assert selected == 2
+    assert msm.lag_time == 2
+
+    csv_path = tmp_path / "ck_mse.csv"
+    png_path = tmp_path / "ck.png"
+    assert csv_path.exists() and png_path.exists()
+
+    out = capsys.readouterr().out
+    assert "Selected τ =" in out


### PR DESCRIPTION
## Summary
- add `select_lag_time_ck` to choose MSM lag by CK MSE plateau with slowest ITS monotonicity
- persist CK MSE table and plot, printing selected τ for final MSM
- cover CK-based τ selection with synthetic MSM test

## Testing
- `pytest tests/test_ck_tau_selection.py tests/test_ck.py tests/test_ck_fallback.py`
- `tox -e py -- tests/test_ck_tau_selection.py tests/test_ck.py tests/test_ck_fallback.py`


------
https://chatgpt.com/codex/tasks/task_e_68aae2ac4ed4832e8e0d3e97ad66601d