### PR TITLE
Add temperature ladder retuning from pairwise acceptance

### DIFF
--- a/src/pmarlo/replica_exchange/diagnostics.py
+++ b/src/pmarlo/replica_exchange/diagnostics.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import json
 from typing import Any, Dict, List
 
 import numpy as np
+from scipy.special import erfcinv
 
 
 def compute_exchange_statistics(
@@ -46,4 +48,96 @@ def compute_exchange_statistics(
         ),
         "round_trip_times": round_trip_times[:10],
         "per_pair_acceptance": per_pair_acceptance,
+    }
+
+
+def retune_temperature_ladder(
+    temperatures: List[float],
+    pair_attempt_counts: Dict[tuple[int, int], int],
+    pair_accept_counts: Dict[tuple[int, int], int],
+    target_acceptance: float = 0.30,
+    output_json: str = "temperatures_suggested.json",
+    dry_run: bool = False,
+) -> Dict[str, Any]:
+    """Suggest a new temperature ladder based on pairwise acceptance.
+
+    Uses the Kofke spacing adjustment to estimate the required inverse-
+    temperature spacing for a desired acceptance rate. The function prints a
+    table summarising current pairwise acceptance and the suggested ``Δβ`` for
+    each neighbour pair and writes a new ladder to ``output_json``.
+
+    Parameters
+    ----------
+    temperatures:
+        Current replica temperatures in Kelvin.
+    pair_attempt_counts:
+        Mapping of ``(i, j)`` neighbour pairs to attempted exchanges.
+    pair_accept_counts:
+        Mapping of ``(i, j)`` neighbour pairs to accepted exchanges.
+    target_acceptance:
+        Desired per-pair acceptance probability (default ``0.30``).
+    output_json:
+        Path to save the suggested temperatures.
+    dry_run:
+        If ``True`` only report the expected speed-up without modifying the
+        replica count.
+
+    Returns
+    -------
+    Dict[str, Any]
+        Dictionary with global acceptance and suggested temperatures.
+    """
+
+    if len(temperatures) < 2:
+        raise ValueError("At least two temperatures are required")
+
+    betas = 1.0 / np.asarray(temperatures, dtype=float)
+    pair_stats: List[Dict[str, Any]] = []
+    total_attempts = 0
+    total_accepts = 0
+
+    print("Pair  Acc%  Suggested Δβ")
+    for i in range(len(temperatures) - 1):
+        pair = (i, i + 1)
+        att = pair_attempt_counts.get(pair, 0)
+        acc = pair_accept_counts.get(pair, 0)
+        rate = acc / max(1, att)
+        total_attempts += att
+        total_accepts += acc
+
+        delta_beta = betas[i + 1] - betas[i]
+        # Clamp rate to avoid division by zero when acceptance is perfect
+        rate_clamped = float(np.clip(rate, 1e-6, 1 - 1e-6))
+        ratio = erfcinv(target_acceptance) / erfcinv(rate_clamped)
+        suggested_dbeta = float(delta_beta * ratio)
+        pair_stats.append(
+            {
+                "pair": pair,
+                "acceptance": rate,
+                "suggested_delta_beta": suggested_dbeta,
+            }
+        )
+        print(f"{pair}  {rate*100:5.1f}%  {suggested_dbeta:10.6f}")
+
+    global_acceptance = total_accepts / max(1, total_attempts)
+
+    avg_dbeta = float(np.mean([p["suggested_delta_beta"] for p in pair_stats]))
+    beta_min = float(betas[0])
+    beta_max = float(betas[-1])
+    n_new = int(round((beta_max - beta_min) / avg_dbeta)) + 1
+    n_new = max(2, n_new)
+    new_betas = np.linspace(beta_min, beta_max, n_new)
+    suggested_temps = (1.0 / new_betas).tolist()
+
+    with open(output_json, "w", encoding="utf-8") as fh:
+        json.dump(suggested_temps, fh)
+
+    if dry_run:
+        speedup = len(temperatures) / len(suggested_temps)
+        print(f"Dry-run: predicted speedup ≈ {speedup:.2f}x")
+
+    return {
+        "global_acceptance": global_acceptance,
+        "suggested_temperatures": suggested_temps,
+        "pair_statistics": pair_stats,
     }

--- a/tests/test_ladder_retuning.py
+++ b/tests/test_ladder_retuning.py
@@ -1,0 +1,30 @@
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from pmarlo.replica_exchange.diagnostics import retune_temperature_ladder
+
+
+def test_retune_temperature_ladder(tmp_path):
+    temps = [300.0, 330.0, 360.0, 390.0]
+    pair_attempt = {(0, 1): 100, (1, 2): 100, (2, 3): 100}
+    pair_accept = {(0, 1): 70, (1, 2): 60, (2, 3): 50}
+    out_file = tmp_path / "temps.json"
+
+    result = retune_temperature_ladder(
+        temps,
+        pair_attempt,
+        pair_accept,
+        target_acceptance=0.30,
+        output_json=str(out_file),
+        dry_run=True,
+    )
+
+    assert out_file.exists()
+    suggested = json.loads(out_file.read_text())
+    assert len(suggested) <= len(temps)
+
+    expected_global = sum(pair_accept.values()) / sum(pair_attempt.values())
+    assert abs(result["global_acceptance"] - expected_global) < 0.02


### PR DESCRIPTION
## Summary
- log per-pair acceptance and suggest inverse temperature spacing using Kofke scaling
- write an adjusted temperature ladder and provide dry-run speedup estimation
- test ladder retuning and global acceptance recomputation

## Testing
- `pytest tests/test_ladder_retuning.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pmarlo')*
- `tox -e py311-no-pdbfixer -q` *(fails: evaluation failed)*

------
https://chatgpt.com/codex/tasks/task_e_68aae2c3ac5c832e8e0193743766b4f7