### PR TITLE
Add enriched MSM state table with free-energy validation

### DIFF
--- a/tests/test_bootstrap_counts.py
+++ b/tests/test_bootstrap_counts.py
@@ -1,0 +1,15 @@
+import numpy as np
+from pmarlo.markov_state_model.markov_state_model import EnhancedMSM
+
+
+def test_bootstrap_counts_consistency(monkeypatch):
+    msm = EnhancedMSM()
+    msm.dtrajs = [np.array([0, 1, 0, 2, 1, 0])]
+    msm.n_states = 3
+    assignments = np.concatenate(msm.dtrajs)
+    counts = np.bincount(assignments, minlength=msm.n_states)
+    rng = np.random.default_rng(0)
+    monkeypatch.setattr(np.random, "default_rng", lambda: rng)
+    samples = msm._bootstrap_counts(assignments, n_boot=500)
+    mean_counts = samples.mean(axis=0)
+    assert np.allclose(mean_counts, counts, atol=0.1 * counts.max())


### PR DESCRIPTION
## Summary
- expand MSM state table with counts, populations, free energies, mean φ/ψ, and representative frame indices
- add bootstrap-based error estimation and save free energy bar plot
- test statistical consistency of bootstrap resampling of counts

## Testing
- `pytest` *(fails: 37 errors during collection)*
- `tox` *(fails: environment build interrupted, missing deps)*

------
https://chatgpt.com/codex/tasks/task_e_68aae2f6ab88832e8f885f4d16cd1fbd