### PR TITLE
Ensure feature extraction uses all frames

### DIFF
--- a/src/pmarlo/fes/ramachandran.py
+++ b/src/pmarlo/fes/ramachandran.py
@@ -175,16 +175,13 @@ def compute_ramachandran_fes(
         Standard deviation for Gaussian smoothing. ``None`` or ``0`` disables
         smoothing.
     stride
-        Use every ``stride``-th frame. If ``None``, determined from ``tau``.
+        Use every ``stride``-th frame. Defaults to ``1`` (use all frames).
     tau
-        Correlation time in frames. If provided and ``stride`` is ``None``, the
-        stride defaults to ``max(1, int(tau / 2))``.
+        Correlation time in frames. Retained for compatibility but no longer
+        alters the frame stride.
     """
 
-    if stride is None:
-        stride = max(1, int(tau / 2)) if tau is not None else 1
-    stride = max(1, int(stride))
-
+    stride = max(1, int(stride or 1))
     angles = compute_ramachandran(traj, selection)[::stride]
     H, xedges, yedges = periodic_hist2d(
         angles[:, 0], angles[:, 1], bins=bins, smoothing=smoothing

--- a/src/pmarlo/markov_state_model/markov_state_model.py
+++ b/src/pmarlo/markov_state_model/markov_state_model.py
@@ -728,7 +728,7 @@ class EnhancedMSM:
             Desired number of TICA components.  ``None`` skips projection.
         lag:
             Lag time (in frames) used in the TICA estimation and to discard the
-            first ``lag`` frames of each trajectory after transformation.
+            first ``lag`` frames of the combined trajectory after transformation.
         """
         if self.features is None or n_components_hint is None:
             return
@@ -745,9 +745,17 @@ class EnhancedMSM:
 
             tica = _DT_TICA(lagtime=int(max(1, lag or 1)), dim=n_components)
             tica_model = tica.fit(Xs).fetch_model()
-            Ys = [tica_model.transform(x)[int(max(0, lag)) :] for x in Xs]
+            Ys = [tica_model.transform(x) for x in Xs]
             self.features = np.vstack(Ys)
-            self.trajectories = [traj[int(max(0, lag)) :] for traj in self.trajectories]
+            if lag > 0:
+                drop = int(max(0, lag))
+                self.features = self.features[drop:]
+                remaining = drop
+                while self.trajectories and remaining >= self.trajectories[0].n_frames:
+                    remaining -= self.trajectories[0].n_frames
+                    self.trajectories.pop(0)
+                if self.trajectories and remaining > 0:
+                    self.trajectories[0] = self.trajectories[0][remaining:]
             if hasattr(tica_model, "eigenvectors_"):
                 self.tica_components_ = tica_model.eigenvectors_  # type: ignore[attr-defined]
             if hasattr(tica_model, "eigenvalues_"):
@@ -757,10 +765,14 @@ class EnhancedMSM:
         except Exception as e:
             logger.warning("deeptime TICA failed (%s); proceeding without TICA", e)
             if lag > 0:
-                self.features = self.features[int(max(0, lag)) :]
-                self.trajectories = [
-                    traj[int(max(0, lag)) :] for traj in self.trajectories
-                ]
+                drop = int(max(0, lag))
+                self.features = self.features[drop:]
+                remaining = drop
+                while self.trajectories and remaining >= self.trajectories[0].n_frames:
+                    remaining -= self.trajectories[0].n_frames
+                    self.trajectories.pop(0)
+                if self.trajectories and remaining > 0:
+                    self.trajectories[0] = self.trajectories[0][remaining:]
 
     def _build_standard_msm(self, lag_time: int, count_mode: str = "sliding") -> None:
         """Estimate transition counts and matrix for a discrete MSM.

--- a/tests/test_frame_accounting.py
+++ b/tests/test_frame_accounting.py
@@ -1,9 +1,9 @@
 import logging
-import numpy as np
-import mdtraj as md
-import pytest
-
 from pathlib import Path
+
+import mdtraj as md
+import numpy as np
+import pytest
 
 from pmarlo.markov_state_model.markov_state_model import EnhancedMSM
 
@@ -30,3 +30,11 @@ def test_effective_frames_and_tau_guard(
     with pytest.raises(ValueError):
         msm.build_msm(lag_time=200)
     assert f"effective frames after lag 200: {expected}" in caplog.text
+
+
+def test_used_frames_with_tica_lag(tmp_path: Path) -> None:
+    traj = _dummy_traj(1000)
+    msm = EnhancedMSM(output_dir=str(tmp_path))
+    msm.trajectories = [traj]
+    msm.compute_features(tica_lag=100, tica_components=2)
+    assert msm.effective_frames >= 900


### PR DESCRIPTION
## Summary
- Avoid per-trajectory frame loss when applying TICA by trimming only once after combining trajectories
- Ramachandran FES now defaults to using all frames and no longer derives stride from tau
- Add regression test confirming that a 1000‑frame trajectory retains at least 900 frames after TICA lag 100

## Testing
- `tox -q` *(fails: tests/test_experiments_paths.py::test_cli_tests_data_dir_points_to_repo_tests, tests/test_experiments_paths.py::test_suite_helpers_resolve_test_data, tests/test_simulation.py::TestDeterministicSimulation::test_deterministic_run_with_seed)*
- `.tox/py312-no-pdbfixer/bin/pytest tests/test_frame_accounting.py::test_used_frames_with_tica_lag -q`


------
https://chatgpt.com/codex/tasks/task_e_68aae2419cf4832ea883dc5c84b90704