### PR TITLE
feat: add ladder tuning

### DIFF
--- a/src/pmarlo/__init__.py
+++ b/src/pmarlo/__init__.py
@@ -8,8 +8,6 @@ A Python package for protein simulation and Markov state model chain generation,
 providing an OpenMM-like interface for molecular dynamics simulations.
 """
 
-from .markov_state_model.markov_state_model import EnhancedMSM as MarkovStateModel
-from .pipeline import LegacyPipeline, Pipeline
 from .protein.protein import Protein
 from .replica_exchange.config import RemdConfig
 from .replica_exchange.replica_exchange import ReplicaExchange
@@ -17,6 +15,18 @@ from .simulation.simulation import Simulation
 from .utils.msm_utils import candidate_lag_ladder
 from .utils.replica_utils import power_of_two_temperature_ladder
 from .utils.seed import quiet_external_loggers
+
+try:  # Lazy imports: these modules may require heavy dependencies
+    from .pipeline import LegacyPipeline, Pipeline
+except Exception:  # pragma: no cover
+    LegacyPipeline = Pipeline = None  # type: ignore[assignment]
+
+try:  # Markov state model may be unavailable in minimal installs
+    from .markov_state_model.markov_state_model import (
+        EnhancedMSM as MarkovStateModel,
+    )
+except Exception:  # pragma: no cover - defensive against optional deps
+    MarkovStateModel = None  # type: ignore[assignment]
 
 __version__ = "0.1.0"
 __author__ = "PMARLO Development Team"
@@ -26,13 +36,16 @@ __all__ = [
     "Protein",
     "ReplicaExchange",
     "RemdConfig",
-    "MarkovStateModel",
     "Simulation",
-    "Pipeline",
-    "LegacyPipeline",
     "power_of_two_temperature_ladder",
     "candidate_lag_ladder",
 ]
+
+if MarkovStateModel is not None:
+    __all__.insert(3, "MarkovStateModel")
+
+if Pipeline is not None and LegacyPipeline is not None:
+    __all__.extend(["Pipeline", "LegacyPipeline"])
 
 # Reduce noise from third-party libraries upon import
 quiet_external_loggers()

--- a/src/pmarlo/replica_exchange/config.py
+++ b/src/pmarlo/replica_exchange/config.py
@@ -26,4 +26,5 @@ class RemdConfig:
 
     # Diagnostics/targets
     target_frames_per_replica: int = 5000
+    target_accept: float = 0.30
     random_seed: Optional[int] = None

--- a/tests/test_ladder_retuning.py
+++ b/tests/test_ladder_retuning.py
@@ -5,6 +5,8 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
 from pmarlo.replica_exchange.diagnostics import retune_temperature_ladder
+from pmarlo.replica_exchange.replica_exchange import ReplicaExchange
+import pytest
 
 
 def test_retune_temperature_ladder(tmp_path):
@@ -28,3 +30,22 @@ def test_retune_temperature_ladder(tmp_path):
 
     expected_global = sum(pair_accept.values()) / sum(pair_attempt.values())
     assert abs(result["global_acceptance"] - expected_global) < 0.02
+
+
+def test_replica_exchange_tune(tmp_path):
+    pdb = str(Path(__file__).parent / "data" / "3gd8.pdb")
+    temps = [300.0, 330.0, 360.0, 390.0]
+    remd = ReplicaExchange(
+        pdb_file=pdb,
+        temperatures=temps,
+        output_dir=str(tmp_path),
+        auto_setup=False,
+        target_accept=0.3,
+    )
+    remd.pair_attempt_counts = {(0, 1): 100, (1, 2): 100, (2, 3): 100}
+    remd.pair_accept_counts = {(0, 1): 70, (1, 2): 60, (2, 3): 50}
+    new_temps = remd.tune_temperature_ladder()
+    assert new_temps[0] == pytest.approx(temps[0])
+    assert new_temps[-1] == pytest.approx(temps[-1])
+    assert len(new_temps) < len(temps)
+    assert remd.n_replicas == len(new_temps)


### PR DESCRIPTION
## Summary
- make pipeline and MSM imports optional for lightweight usage
- support temperature ladder tuning with a target acceptance rate
- expose ladder tuning hooks and defaults in ReplicaExchange utilities

## Testing
- `pytest tests/test_ladder_retuning.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pmarlo')*
- `tox -q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aaec0f999c832ea25de87aaf9dd09a