### PR TITLE
refactor: centralize system and platform setup

### DIFF
--- a/src/pmarlo/replica_exchange/replica_exchange.py
+++ b/src/pmarlo/replica_exchange/replica_exchange.py
@@ -34,6 +34,7 @@ from .system_builder import (
 from .trajectory import ClosableDCDReporter
 from ..results import REMDResult
 from ..utils.replica_utils import exponential_temperature_ladder
+from ..utils.integrator import create_langevin_integrator
 
 logger = logging.getLogger("pmarlo")
 
@@ -382,17 +383,7 @@ class ReplicaExchange:
     def _create_integrator_for_temperature(
         self, temperature: float
     ) -> openmm.Integrator:
-        integrator = openmm.LangevinIntegrator(
-            temperature * unit.kelvin,
-            1.0 / unit.picosecond,
-            2.0 * unit.femtoseconds,
-        )
-        # Seed integrator RNG for reproducibility
-        try:
-            integrator.setRandomNumberSeed(int(self.random_seed))
-        except Exception:
-            pass
-        return integrator
+        return create_langevin_integrator(temperature, self.random_seed)
 
     def _create_simulation(
         self,

--- a/src/pmarlo/utils/integrator.py
+++ b/src/pmarlo/utils/integrator.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from typing import Optional
+
+import openmm
+import openmm.unit as unit
+
+
+def create_langevin_integrator(
+    temperature: float, random_seed: Optional[int] = None
+) -> openmm.Integrator:
+    """Create a Langevin integrator with common defaults.
+
+    Parameters
+    ----------
+    temperature:
+        Temperature in Kelvin for the integrator.
+    random_seed:
+        Optional seed for deterministic behaviour.
+    """
+    integrator = openmm.LangevinIntegrator(
+        temperature * unit.kelvin,
+        1.0 / unit.picosecond,
+        2.0 * unit.femtoseconds,
+    )
+    if random_seed is not None:
+        try:
+            integrator.setRandomNumberSeed(int(random_seed))
+        except Exception:
+            pass
+    return integrator


### PR DESCRIPTION
## Summary
- reuse replica-exchange system builder and platform selector in simulation
- centralize Langevin integrator creation in a shared utility
- have ReplicaExchange rely on the shared integrator builder

## Testing
- `pytest --maxfail=1`
- `tox -e py312-no-pdbfixer -- --maxfail=1` (fails: KeyboardInterrupt)


------
https://chatgpt.com/codex/tasks/task_e_68acdb967b40832e9bb300c84e2fcda3