### PR TITLE
Propagate user random seed through feature extraction

### DIFF
--- a/src/pmarlo/markov_state_model/_states.py
+++ b/src/pmarlo/markov_state_model/_states.py
@@ -164,7 +164,8 @@ class StatesMixin:
                 comps = np.real(eigvecs[:, order[1 : 1 + k]])
                 from sklearn.cluster import MiniBatchKMeans
 
-                km = MiniBatchKMeans(n_clusters=n_macrostates, random_state=42)
+                rng = getattr(self, "random_state", 42)
+                km = MiniBatchKMeans(n_clusters=n_macrostates, random_state=rng)
                 labels = km.fit_predict(comps)
                 return labels.astype(int)
             except Exception:

--- a/src/pmarlo/simulation/simulation.py
+++ b/src/pmarlo/simulation/simulation.py
@@ -132,7 +132,9 @@ class Simulation:
 
     def extract_features(self, trajectory_file: str) -> np.ndarray:
         """Extract features from trajectory for MSM analysis."""
-        states = feature_extraction(trajectory_file, self.pdb_file)
+        states = feature_extraction(
+            trajectory_file, self.pdb_file, random_state=self.random_seed
+        )
         return np.array(states)
 
     def run_complete_simulation(self) -> Tuple[str, np.ndarray]:
@@ -499,8 +501,20 @@ def production_run(steps, simulation, meta, output_dir=None):
     return dcd_filename
 
 
-def feature_extraction(dcd_path, pdb_path):
-    """Extract features from trajectory for MSM analysis."""
+def feature_extraction(dcd_path, pdb_path, random_state: int | None = 0):
+    """Extract features from trajectory for MSM analysis.
+
+    Parameters
+    ----------
+    dcd_path:
+        Path to the trajectory file in DCD format.
+    pdb_path:
+        Path to the corresponding PDB topology file.
+    random_state:
+        Seed for deterministic clustering.  When ``None`` a random seed is
+        used, otherwise the provided seed ensures reproducible clustering.
+        Defaults to ``0`` for backward compatibility with earlier releases.
+    """
     print("Stage 4/5  –  featurisation + clustering ...")
 
     # Load the trajectory and compute φ dihedral angles
@@ -511,7 +525,7 @@ def feature_extraction(dcd_path, pdb_path):
     X = np.cos(phi_vals)
     X = X.reshape(-1, 1)
 
-    kmeans = MiniBatchKMeans(n_clusters=40, random_state=0).fit(X)
+    kmeans = MiniBatchKMeans(n_clusters=40, random_state=random_state).fit(X)
     states = kmeans.labels_
     print("✔ Clustering done\n")
     return states

--- a/tests/test_feature_extraction_seed.py
+++ b/tests/test_feature_extraction_seed.py
@@ -1,0 +1,24 @@
+from unittest.mock import patch
+
+import numpy as np
+
+from pmarlo.simulation.simulation import feature_extraction
+
+
+def test_feature_extraction_passes_random_state(
+    test_trajectory_file, test_fixed_pdb_file
+):
+    """feature_extraction should forward the provided random_state to KMeans."""
+    with patch("pmarlo.simulation.simulation.MiniBatchKMeans") as MBK:
+        instance = MBK.return_value
+        instance.fit.return_value = instance
+        instance.labels_ = np.array([0])
+
+        feature_extraction(
+            str(test_trajectory_file),
+            str(test_fixed_pdb_file),
+            random_state=123,
+        )
+
+        MBK.assert_called_with(n_clusters=40, random_state=123)
+        instance.fit.assert_called_once()


### PR DESCRIPTION
## Summary
- Respect Simulation.random_seed in feature extraction by forwarding it to MiniBatchKMeans
- Use model's random_state when performing MiniBatchKMeans in StatesMixin
- Add regression test to ensure feature extraction passes random_state to clustering

## Testing
- `tox -q -e lint`
- `tox -q -e type` *(fails: Missing return statement, attr-defined, etc.)*
- `tox -q -e format`
- `PYTHONPATH=src pytest tests/test_feature_extraction_seed.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68acdbc74c18832e997e5d37027159bb