### PR TITLE
Use shared API for simulation feature extraction

### DIFF
--- a/tests/test_feature_extraction_seed.py
+++ b/tests/test_feature_extraction_seed.py
@@ -8,11 +8,9 @@ from pmarlo.simulation.simulation import feature_extraction
 def test_feature_extraction_passes_random_state(
     test_trajectory_file, test_fixed_pdb_file
 ):
-    """feature_extraction should forward the provided random_state to KMeans."""
-    with patch("pmarlo.simulation.simulation.MiniBatchKMeans") as MBK:
-        instance = MBK.return_value
-        instance.fit.return_value = instance
-        instance.labels_ = np.array([0])
+    """feature_extraction should forward the provided random_state."""
+    with patch("pmarlo.api.cluster_microstates") as cm:
+        cm.return_value = np.array([0])
 
         feature_extraction(
             str(test_trajectory_file),
@@ -20,5 +18,5 @@ def test_feature_extraction_passes_random_state(
             random_state=123,
         )
 
-        MBK.assert_called_with(n_clusters=40, random_state=123)
-        instance.fit.assert_called_once()
+        assert cm.call_args.kwargs["random_state"] == 123
+        assert cm.call_args.kwargs["n_states"] == 40


### PR DESCRIPTION
## Summary
- Route `Simulation.extract_features` through the general API
- Replace manual φ clustering with `api.compute_features` and `api.cluster_microstates`
- Update test to ensure clustering function receives the provided seed

## Testing
- `tox -q -e py311` *(fails: py311: SKIP (0.00 seconds))*
- `pytest` *(terminated: KeyboardInterrupt)*
- `pytest tests/test_feature_extraction_seed.py tests/test_simulation.py::TestSimulation::test_feature_extraction tests/test_simulation.py::TestSimulation::test_simulation_initialization -q`

------
https://chatgpt.com/codex/tasks/task_e_68ad7fe33dec832ebecb22982e08af3d