### PR TITLE
feat: add protein specific descriptors

### DIFF
--- a/src/pmarlo/protein/protein.py
+++ b/src/pmarlo/protein/protein.py
@@ -138,6 +138,8 @@ class Protein:
         self.system = None
         # RDKit molecule object for property calculations
         self.rdkit_mol = None
+        # Cache for RDKit-derived descriptors
+        self._rdkit_properties: Dict[str, Any] = {}
 
     def _initialize_properties_dict(self) -> None:
         # Protein properties
@@ -148,11 +150,9 @@ class Protein:
             "molecular_weight": 0.0,
             "exact_molecular_weight": 0.0,
             "charge": 0.0,
-            "logp": 0.0,
-            "hbd": 0,  # Hydrogen bond donors
-            "hba": 0,  # Hydrogen bond acceptors
-            "rotatable_bonds": 0,
-            "aromatic_rings": 0,
+            "isoelectric_point": 0.0,
+            "hydrophobic_fraction": 0.0,
+            "aromatic_residues": 0,
             "heavy_atoms": 0,
         }
 
@@ -210,18 +210,9 @@ class Protein:
         self.properties["exact_molecular_weight"] = total_mass
         self.properties["heavy_atoms"] = heavy_atoms
 
-        # Keep numeric defaults for descriptors when RDKit not used
-        # (tests expect ints/floats, not None)
-        self.properties["charge"] = float(self.properties.get("charge", 0.0))
-        self.properties["logp"] = float(self.properties.get("logp", 0.0))
-        self.properties["hbd"] = int(self.properties.get("hbd", 0))
-        self.properties["hba"] = int(self.properties.get("hba", 0))
-        self.properties["rotatable_bonds"] = int(
-            self.properties.get("rotatable_bonds", 0)
-        )
-        self.properties["aromatic_rings"] = int(
-            self.properties.get("aromatic_rings", 0)
-        )
+        sequence = self._sequence_from_topology(topo)
+        metrics = self._compute_protein_metrics(sequence)
+        self.properties.update(metrics)
 
     def prepare(
         self,
@@ -309,44 +300,64 @@ class Protein:
         self._validate_coordinates(self.positions)
 
     def _calculate_properties(self):
-        """Calculate protein properties using RDKit."""
+        """Calculate basic protein properties."""
         if self.topology is None:
             return
 
-        # Basic topology properties
         self.properties["num_atoms"] = len(list(self.topology.atoms()))
         self.properties["num_residues"] = len(list(self.topology.residues()))
         self.properties["num_chains"] = len(list(self.topology.chains()))
 
-        self._calculate_rdkit_properties()
+        total_mass = 0.0
+        heavy_atoms = 0
+        for atom in self.topology.atoms():
+            mass = getattr(atom.element, "mass", None)
+            if mass is None:
+                mass = 0.0
+            total_mass += float(mass)
+            if getattr(atom.element, "number", 0) != 1:
+                heavy_atoms += 1
+        self.properties["molecular_weight"] = total_mass
+        self.properties["exact_molecular_weight"] = total_mass
+        self.properties["heavy_atoms"] = heavy_atoms
 
-    def _calculate_rdkit_properties(self):
+        sequence = self._sequence_from_topology(self.topology)
+        metrics = self._compute_protein_metrics(sequence)
+        self.properties.update(metrics)
+
+    def _calculate_rdkit_properties(self) -> Dict[str, Any]:
         """Calculate properties using RDKit for accurate molecular analysis."""
+        props: Dict[str, Any] = {}
         try:
-            # Use helper function for temporary file handling
             tmp_pdb = self._create_temp_pdb()
             self.rdkit_mol = Chem.MolFromPDBFile(tmp_pdb)
 
             if self.rdkit_mol is not None:
-                self._compute_rdkit_descriptors()
+                props = self._compute_rdkit_descriptors()
             else:
                 print("Warning: Could not load molecule into RDKit.")
 
         except Exception as e:
             print(f"Warning: RDKit calculation failed: {e}")
         finally:
-            # Clean up temporary file
             if "tmp_pdb" in locals():
                 self._cleanup_temp_file(tmp_pdb)
 
+        self._rdkit_properties = props
+        return props
+
     def _create_temp_pdb(self) -> str:
         """Create a temporary PDB file for RDKit processing."""
+        import shutil
         import tempfile
 
         with tempfile.NamedTemporaryFile(suffix=".pdb", delete=False) as tmp_file:
             tmp_pdb = tmp_file.name
 
-        self.save_prepared_pdb(tmp_pdb)
+        if self.prepared and HAS_PDBFIXER and self.fixer is not None:
+            self.save_prepared_pdb(tmp_pdb)
+        else:
+            shutil.copy2(self.pdb_file, tmp_pdb)
         return tmp_pdb
 
     def _cleanup_temp_file(self, tmp_file: str):
@@ -356,26 +367,121 @@ class Protein:
         except Exception:
             pass
 
+    # --- Protein-specific descriptor helpers ---
+
+    def _sequence_from_topology(self, topology) -> str:
+        """Extract amino acid sequence from a topology object."""
+        aa3_to1 = {
+            "ALA": "A",
+            "ARG": "R",
+            "ASN": "N",
+            "ASP": "D",
+            "CYS": "C",
+            "GLU": "E",
+            "GLN": "Q",
+            "GLY": "G",
+            "HIS": "H",
+            "ILE": "I",
+            "LEU": "L",
+            "LYS": "K",
+            "MET": "M",
+            "PHE": "F",
+            "PRO": "P",
+            "SER": "S",
+            "THR": "T",
+            "TRP": "W",
+            "TYR": "Y",
+            "VAL": "V",
+        }
+
+        residues_iter = getattr(topology, "residues", [])
+        if callable(residues_iter):
+            residues_iter = residues_iter()
+
+        sequence = []
+        for res in residues_iter:
+            code = aa3_to1.get(res.name.upper(), "")
+            if code:
+                sequence.append(code)
+        return "".join(sequence)
+
+    def _compute_protein_metrics(self, sequence: str) -> Dict[str, Any]:
+        """Compute protein-specific metrics from an amino acid sequence."""
+        if not sequence:
+            return {
+                "charge": 0.0,
+                "isoelectric_point": 0.0,
+                "hydrophobic_fraction": 0.0,
+                "aromatic_residues": 0,
+            }
+
+        counts = {aa: sequence.count(aa) for aa in set(sequence)}
+        n_res = len(sequence)
+
+        hydrophobic = set("AVILMFYWPG")
+        aromatic = set("FYW")
+
+        num_hydrophobic = sum(counts.get(aa, 0) for aa in hydrophobic)
+        num_aromatic = sum(counts.get(aa, 0) for aa in aromatic)
+
+        hydrophobic_fraction = num_hydrophobic / n_res if n_res else 0.0
+
+        # pKa values for side chains, N-terminus, C-terminus
+        pka_side = {
+            "C": 8.3,
+            "D": 3.9,
+            "E": 4.1,
+            "H": 6.0,
+            "K": 10.5,
+            "R": 12.5,
+            "Y": 10.1,
+        }
+        pka_n = 9.69
+        pka_c = 2.34
+
+        def charge_at_ph(ph: float) -> float:
+            pos = 10 ** (pka_n - ph) / (1 + 10 ** (pka_n - ph))
+            neg = 10 ** (ph - pka_c) / (1 + 10 ** (ph - pka_c))
+            for aa, count in counts.items():
+                if aa in ["K", "R", "H"]:
+                    pk = pka_side[aa]
+                    pos += count * (10 ** (pk - ph) / (1 + 10 ** (pk - ph)))
+                elif aa in ["D", "E", "C", "Y"]:
+                    pk = pka_side[aa]
+                    neg += count * (10 ** (ph - pk) / (1 + 10 ** (ph - pk)))
+            return pos - neg
+
+        # Estimate pI by scanning pH 0-14
+        pI = 0.0
+        min_charge = float("inf")
+        for pH in [x / 100 for x in range(0, 1401)]:
+            c = abs(charge_at_ph(pH))
+            if c < min_charge:
+                min_charge = c
+                pI = pH
+
+        charge = charge_at_ph(self.ph)
+
+        return {
+            "charge": charge,
+            "isoelectric_point": pI,
+            "hydrophobic_fraction": hydrophobic_fraction,
+            "aromatic_residues": num_aromatic,
+        }
+
     def _compute_rdkit_descriptors(self):
         """Compute RDKit molecular descriptors."""
-        # Calculate exact molecular weight
-        self.properties["exact_molecular_weight"] = CalcExactMolWt(self.rdkit_mol)
-
-        # Calculate various molecular descriptors
-        self.properties["logp"] = Descriptors.MolLogP(self.rdkit_mol)
-        self.properties["hbd"] = Descriptors.NumHDonors(self.rdkit_mol)
-        self.properties["hba"] = Descriptors.NumHAcceptors(self.rdkit_mol)
-        self.properties["rotatable_bonds"] = Descriptors.NumRotatableBonds(
-            self.rdkit_mol
-        )
-        self.properties["aromatic_rings"] = Descriptors.NumAromaticRings(self.rdkit_mol)
-        self.properties["heavy_atoms"] = Descriptors.HeavyAtomCount(self.rdkit_mol)
-
-        # Calculate formal charge
-        self.properties["charge"] = Chem.GetFormalCharge(self.rdkit_mol)
-
-        # Use exact molecular weight
-        self.properties["molecular_weight"] = self.properties["exact_molecular_weight"]
+        props: Dict[str, Any] = {}
+        props["exact_molecular_weight"] = CalcExactMolWt(self.rdkit_mol)
+        props["molecular_weight"] = props["exact_molecular_weight"]
+        props["logp"] = Descriptors.MolLogP(self.rdkit_mol)
+        props["hbd"] = Descriptors.NumHDonors(self.rdkit_mol)
+        props["hba"] = Descriptors.NumHAcceptors(self.rdkit_mol)
+        props["rotatable_bonds"] = Descriptors.NumRotatableBonds(self.rdkit_mol)
+        props["aromatic_rings"] = Descriptors.NumAromaticRings(self.rdkit_mol)
+        props["heavy_atoms"] = Descriptors.HeavyAtomCount(self.rdkit_mol)
+        props["charge"] = Chem.GetFormalCharge(self.rdkit_mol)
+        return props
 
     def get_rdkit_molecule(self):
         """
@@ -398,25 +504,28 @@ class Protein:
         """
         properties = self.properties.copy()
 
-        if detailed and self.rdkit_mol is not None:
-            try:
-                properties.update(
-                    {
-                        "tpsa": Descriptors.TPSA(
-                            self.rdkit_mol
-                        ),  # Topological polar surface area
-                        "molar_refractivity": Descriptors.MolMR(self.rdkit_mol),
-                        "fraction_csp3": Descriptors.FractionCsp3(self.rdkit_mol),
-                        "ring_count": Descriptors.RingCount(self.rdkit_mol),
-                        "spiro_atoms": Descriptors.NumSpiroAtoms(self.rdkit_mol),
-                        "bridgehead_atoms": Descriptors.NumBridgeheadAtoms(
-                            self.rdkit_mol
-                        ),
-                        "heteroatoms": Descriptors.NumHeteroatoms(self.rdkit_mol),
-                    }
-                )
-            except Exception as e:
-                print(f"Warning: Some RDKit descriptors failed: {e}")
+        if detailed:
+            if not self._rdkit_properties:
+                self._rdkit_properties = self._calculate_rdkit_properties()
+            properties.update(self._rdkit_properties)
+
+            if self.rdkit_mol is not None:
+                try:
+                    properties.update(
+                        {
+                            "tpsa": Descriptors.TPSA(self.rdkit_mol),
+                            "molar_refractivity": Descriptors.MolMR(self.rdkit_mol),
+                            "fraction_csp3": Descriptors.FractionCsp3(self.rdkit_mol),
+                            "ring_count": Descriptors.RingCount(self.rdkit_mol),
+                            "spiro_atoms": Descriptors.NumSpiroAtoms(self.rdkit_mol),
+                            "bridgehead_atoms": Descriptors.NumBridgeheadAtoms(
+                                self.rdkit_mol
+                            ),
+                            "heteroatoms": Descriptors.NumHeteroatoms(self.rdkit_mol),
+                        }
+                    )
+                except Exception as e:
+                    print(f"Warning: Some RDKit descriptors failed: {e}")
 
         return properties
 

--- a/tests/test_protein.py
+++ b/tests/test_protein.py
@@ -41,6 +41,9 @@ class TestProtein:
                     "molecular_weight",
                     "charge",
                     "isoelectric_point",
+                    "hydrophobic_fraction",
+                    "aromatic_residues",
+                    "heavy_atoms",
                 ]
             )
             # When PDBFixer is unavailable, defaults may not be zero; ensure keys exist and values are ints
@@ -244,3 +247,33 @@ class TestProteinAdditional:
             pytest.skip("OpenMM required")
         with pytest.raises(ValueError, match="non-finite"):
             Protein(str(nan_pdb_file), auto_prepare=False)
+
+
+class TestProteinMetrics:
+    """Tests for low-level protein metric helpers."""
+
+    def test_compute_protein_metrics_known_sequence(self):
+        """Verify metric calculation on a known sequence."""
+        protein = object.__new__(Protein)
+        protein.ph = 7.0
+        seq = "ACDEFGHIKLMNPQRSTVWY"  # 20 amino acids, 10 hydrophobic, 3 aromatic
+        metrics = Protein._compute_protein_metrics(protein, seq)
+
+        assert metrics["hydrophobic_fraction"] == pytest.approx(0.5)
+        assert metrics["aromatic_residues"] == 3
+        assert 0.0 <= metrics["isoelectric_point"] <= 14.0
+        assert isinstance(metrics["charge"], float)
+
+    def test_sequence_from_topology(self):
+        """Ensure sequence extraction from topology is correct."""
+        from openmm.app import Topology, element
+
+        protein = object.__new__(Protein)
+        top = Topology()
+        chain = top.addChain("A")
+        for res_name in ("ALA", "GLY", "PHE"):
+            res = top.addResidue(res_name, chain)
+            top.addAtom("N", element.get_by_symbol("N"), res)
+
+        seq = Protein._sequence_from_topology(protein, top)
+        assert seq == "AGF"

--- a/tests/test_protein.py
+++ b/tests/test_protein.py
@@ -40,12 +40,22 @@ class TestProtein:
                     "num_chains",
                     "molecular_weight",
                     "charge",
-                    "logp",
+                    "isoelectric_point",
                 ]
             )
             # When PDBFixer is unavailable, defaults may not be zero; ensure keys exist and values are ints
             for key in properties:
                 assert isinstance(properties[key], (int, float))
+
+    def test_optional_rdkit_descriptors(self, test_pdb_file):
+        """RDKit descriptors are only added when detailed=True."""
+        with patch("pmarlo.protein.protein.HAS_PDBFIXER", False):
+            protein = Protein(str(test_pdb_file), auto_prepare=False)
+            props = protein.get_properties()
+            assert "logp" not in props
+
+            detailed = protein.get_properties(detailed=True)
+            assert "logp" in detailed
 
     def test_protein_save_without_pdbfixer(self, test_pdb_file, temp_output_dir):
         """Test that saving without PDBFixer raises appropriate error."""


### PR DESCRIPTION
## Summary
- replace small-molecule RDKit descriptors with protein-oriented metrics
- compute isoelectric point and hydrophobic fraction from sequences
- expose RDKit descriptors only when detailed flag requested

## Testing
- `pytest` *(fails: 45 errors during collection)*
- `tox` *(fails: mypy errors in markov_state_model pipeline)*

------
https://chatgpt.com/codex/tasks/task_e_68ad80199830832ea2aa9f86ba18d14f