### PR TITLE
feat: add optional solvation

### DIFF
--- a/changelog.d/20250826_094526_solvation_option.md
+++ b/changelog.d/20250826_094526_solvation_option.md
@@ -1,0 +1,5 @@
+### Added
+- Optional solvation step that adds an explicit water box when none is present.
+
+### Changed
+- Water molecules are now preserved during protein preparation by default.

--- a/tests/test_protein.py
+++ b/tests/test_protein.py
@@ -150,6 +150,23 @@ class TestProtein:
             system_info = protein.get_system_info()
             assert not system_info["system_created"]
 
+    @pytest.mark.pdbfixer
+    def test_solvation_option(self, test_fixed_pdb_file):
+        """Solvate proteins lacking water when requested."""
+        protein = Protein(str(test_fixed_pdb_file), auto_prepare=False)
+        protein.prepare()
+        water_residues = {
+            res for res in protein.topology.residues() if res.name in {"HOH", "H2O", "WAT"}
+        }
+        assert len(water_residues) == 0
+
+        protein = Protein(str(test_fixed_pdb_file), auto_prepare=False)
+        protein.prepare(solvate=True)
+        water_residues = {
+            res for res in protein.topology.residues() if res.name in {"HOH", "H2O", "WAT"}
+        }
+        assert len(water_residues) > 0
+
 
 class TestProteinIntegration:
     """Integration tests for Protein class."""


### PR DESCRIPTION
## Summary
- keep crystallographic waters by default during protein preparation
- add optional solvation step to introduce an explicit water box when missing
- test solvation behavior and document change in changelog

## Testing
- `tox -e py311` *(fails: Could not find a version that satisfies the requirement pdbfixer>=1.9)*

------
https://chatgpt.com/codex/tasks/task_e_68ad80325384832e980bc10683d8bb12