### PR TITLE
Expose mapping from periodic feature expansion

### DIFF
--- a/tests/test_trig_expand_mapping.py
+++ b/tests/test_trig_expand_mapping.py
@@ -1,0 +1,17 @@
+import sys
+from pathlib import Path
+
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+from pmarlo.api import _trig_expand_periodic
+
+
+def test_trig_expand_returns_mapping():
+    X = np.array([[0.0, 1.0], [2.0, 3.0]])
+    periodic = np.array([True, False])
+    Xe, mapping = _trig_expand_periodic(X, periodic)
+    assert Xe.shape == (2, 3)
+    assert mapping == {0: (0, 1), 1: (2,)}
+    expected = np.column_stack([np.cos(X[:, 0]), np.sin(X[:, 0]), X[:, 1]])
+    assert np.allclose(Xe, expected)


### PR DESCRIPTION
## Summary
- return column mapping alongside trig expansion of periodic features
- include mapping metadata in universal metric and embedding helpers
- add unit test for trig expansion mapping

## Testing
- `pytest` *(fails: 32 errors during collection)*
- `poetry run tox -q` *(fails: Command not found: tox)*

------
https://chatgpt.com/codex/tasks/task_e_68aeed039c3c832e9ee8423ed4211605