### PR TITLE
Add cached naming helpers for reproducible replica state logging

### DIFF
--- a/src/pmarlo/replica_exchange/replica_exchange.py
+++ b/src/pmarlo/replica_exchange/replica_exchange.py
@@ -35,6 +35,7 @@ from .trajectory import ClosableDCDReporter
 from ..results import REMDResult
 from ..utils.replica_utils import exponential_temperature_ladder
 from ..utils.integrator import create_langevin_integrator
+from ..utils.naming import base_shape_str, permutation_name
 
 logger = logging.getLogger("pmarlo")
 
@@ -944,6 +945,13 @@ class ReplicaExchange:
 
         self.replica_states[replica_i] = old_state_j
         self.replica_states[replica_j] = old_state_i
+
+        # Cache a deterministic name for the new permutation of replicas.
+        shape_name = base_shape_str((len(self.replica_states),))
+        perm_name = permutation_name(tuple(self.replica_states))
+        logger.debug(
+            "Replica state permutation %s applied (shape %s)", perm_name, shape_name
+        )
 
         self.state_replicas[old_state_i] = replica_j
         self.state_replicas[old_state_j] = replica_i

--- a/src/pmarlo/utils/naming.py
+++ b/src/pmarlo/utils/naming.py
@@ -1,0 +1,49 @@
+"""Helpers for reproducible naming of remaps and permutations.
+
+These functions provide small cached layers that convert array shapes and
+permutation mappings into deterministic strings.  By caching the results
+we ensure that repeated calls across a workflow yield identical objects,
+which simplifies logging and makes debugging across passes repeatable.
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Tuple
+
+
+@lru_cache(maxsize=None)
+def base_shape_str(shape: Tuple[int, ...]) -> str:
+    """Return a canonical string representation for ``shape``.
+
+    Parameters
+    ----------
+    shape:
+        Tuple describing the base shape of an array or collection.
+
+    Returns
+    -------
+    str
+        A string formatted as ``"d0xd1x..."`` that can be used as a
+        deterministic identifier in logs.
+    """
+
+    return "x".join(str(int(dim)) for dim in shape)
+
+
+@lru_cache(maxsize=None)
+def permutation_name(mapping: Tuple[int, ...]) -> str:
+    """Return a stable name for a permutation mapping.
+
+    Parameters
+    ----------
+    mapping:
+        The permutation as a tuple of indices.
+
+    Returns
+    -------
+    str
+        Deterministic string representing the permutation.
+    """
+
+    return "-".join(str(int(idx)) for idx in mapping)

--- a/tests/unit/utils/test_naming.py
+++ b/tests/unit/utils/test_naming.py
@@ -1,0 +1,20 @@
+import pmarlo.utils.naming as naming
+
+
+def test_base_shape_str_cache():
+    naming.base_shape_str.cache_clear()
+    naming.base_shape_str((2, 3))
+    assert naming.base_shape_str.cache_info().hits == 0
+    naming.base_shape_str((2, 3))
+    assert naming.base_shape_str.cache_info().hits == 1
+    assert naming.base_shape_str((2, 3)) == "2x3"
+
+
+def test_permutation_name_cache():
+    naming.permutation_name.cache_clear()
+    perm = (1, 0, 2)
+    naming.permutation_name(perm)
+    assert naming.permutation_name.cache_info().hits == 0
+    naming.permutation_name(perm)
+    assert naming.permutation_name.cache_info().hits == 1
+    assert naming.permutation_name(perm) == "1-0-2"


### PR DESCRIPTION
## Summary
- add `base_shape_str` and `permutation_name` utilities for deterministic string identifiers
- log replica state permutations using cached names for reproducible exchanges
- cover naming cache behaviour with unit tests

## Testing
- `python -m pytest tests/unit/utils/test_naming.py -q`
- `python -m pytest -q` *(fails: FileNotFoundError for 'output/msm_analysis', ImportError for missing PDBFixer, assertion in deterministic run)*
- `tox -q` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aeed53f45c832ea69f7c6429eb1b2c