### PR TITLE
Handle constant axes in FES pair selection

### DIFF
--- a/tests/test_fes_pair_selection.py
+++ b/tests/test_fes_pair_selection.py
@@ -1,0 +1,23 @@
+import numpy as np
+from pmarlo.api import select_fes_pair
+
+
+def test_select_fes_pair_ignores_constant_axes():
+    # First column constant, others varying
+    X = np.array([[1.0, 0.0, 1.0],
+                  [1.0, 1.0, 2.0],
+                  [1.0, 2.0, 3.0]])
+    cols = ["c0", "c1", "c2"]
+    periodic = np.array([False, False, False])
+    i, j, pi, pj = select_fes_pair(X, cols, periodic)
+    assert {i, j} == {1, 2}
+    assert not pi and not pj
+
+
+def test_select_fes_pair_all_constant_folds():
+    X = np.ones((3, 2))
+    cols = ["c0", "c1"]
+    periodic = np.array([False, False])
+    i, j, pi, pj = select_fes_pair(X, cols, periodic)
+    assert (i, j) == (0, 0)
+    assert not pi and not pj


### PR DESCRIPTION
## Summary
- ignore constant CVs when picking FES axes
- fall back to first axis when all CVs are constant
- test FES pair selection with constant and degenerate axes

## Testing
- `PYTHONPATH=src python -m pytest tests/test_fes_pair_selection.py -q`
- `tox -q -e lint`  
- `tox -q -e type` *(fails: _HasStateAttrs has no attribute)*
- `tox -q -e py312-no-pdbfixer,lint` *(partially ran; suite failure at test_bootstrap_counts_consistency)*

------
https://chatgpt.com/codex/tasks/task_e_68aeed49302c832e93e12cc64cda10ee