### PR TITLE
Return index mapping from trig expansion

### DIFF
--- a/src/pmarlo/api.py
+++ b/src/pmarlo/api.py
@@ -61,35 +61,48 @@ def _align_trajectory(
         return traj
 
 
-def _trig_expand_periodic(X: np.ndarray, periodic: np.ndarray) -> np.ndarray:
-    """Expand periodic columns of X into cos/sin, keep non-periodic as-is.
+def _trig_expand_periodic(
+    X: np.ndarray, periodic: np.ndarray
+) -> tuple[np.ndarray, np.ndarray]:
+    """Expand periodic columns of ``X`` into cos/sin pairs.
 
     Parameters
     ----------
     X:
-        Feature matrix of shape (n_frames, n_features).
+        Feature matrix of shape ``(n_frames, n_features)``.
     periodic:
-        Boolean array of shape (n_features,) indicating periodic columns.
+        Boolean array indicating which columns of ``X`` are periodic.
 
     Returns
     -------
-    np.ndarray
-        Expanded feature matrix with shape (n_frames, n_nonperiodic + 2*n_periodic).
+    tuple[np.ndarray, np.ndarray]
+        A pair ``(Xe, mapping)`` where ``Xe`` is the expanded feature matrix
+        and ``mapping`` is an integer array such that ``mapping[k]`` gives the
+        original column index of ``Xe[:, k]``.  Non-periodic columns map 1:1,
+        while periodic columns appear twice in ``Xe`` (cos and sin) and thus
+        duplicate their original index in ``mapping``.
     """
+
     if X.size == 0:
-        return X
+        return X, np.array([], dtype=int)
     if periodic.size != X.shape[1]:
         # Best-effort: assume non-periodic if mismatch
         periodic = np.zeros((X.shape[1],), dtype=bool)
+
     cols: List[np.ndarray] = []
+    mapping: List[int] = []
     for j in range(X.shape[1]):
         col = X[:, j]
         if bool(periodic[j]):
             cols.append(np.cos(col))
             cols.append(np.sin(col))
+            mapping.extend([j, j])
         else:
             cols.append(col)
-    return np.vstack(cols).T if cols else X
+            mapping.append(j)
+
+    Xe = np.vstack(cols).T if cols else X
+    return Xe, np.asarray(mapping, dtype=int)
 
 
 def compute_universal_metric(
@@ -147,7 +160,7 @@ def compute_universal_metric(
             "specs": specs,
         }
     logger.info("[universal] Trig-expanding periodic columns")
-    Xe = _trig_expand_periodic(X, periodic)
+    Xe, index_map = _trig_expand_periodic(X, periodic)
     logger.info("[universal] Expanded shape=%s", tuple(Xe.shape))
     if method == "pca":
         logger.info("[universal] Reducing with PCA → 1D")
@@ -168,6 +181,7 @@ def compute_universal_metric(
         "lag": int(lag),
         "aligned": bool(align),
         "specs": specs,
+        "index_map": index_map,
     }
     return metric, meta
 
@@ -196,7 +210,7 @@ def compute_universal_embedding(
     X, cols, periodic = compute_features(
         traj_in, feature_specs=specs, cache_path=cache_path
     )
-    Xe = _trig_expand_periodic(X, periodic)
+    Xe, index_map = _trig_expand_periodic(X, periodic)
     k = int(max(1, n_components))
     if method == "pca":
         Y = pca_reduce(Xe, n_components=k)
@@ -212,6 +226,7 @@ def compute_universal_embedding(
         "aligned": bool(align),
         "specs": specs,
         "n_components": k,
+        "index_map": index_map,
     }
     return Y, meta
 

--- a/tests/test_trig_expand_mapping.py
+++ b/tests/test_trig_expand_mapping.py
@@ -1,0 +1,17 @@
+import numpy as np
+
+from pmarlo.api import _trig_expand_periodic
+
+
+def test_trig_expand_returns_mapping() -> None:
+    X = np.array([[0.0, 0.1, 0.2], [1.0, 0.3, 0.4]], dtype=float)
+    periodic = np.array([False, True, True])
+    Xe, mapping = _trig_expand_periodic(X, periodic)
+    assert Xe.shape == (2, 5)
+    assert mapping.tolist() == [0, 1, 1, 2, 2]
+    # Verify columns align with cos/sin expansion
+    assert np.allclose(Xe[:, 0], X[:, 0])
+    assert np.allclose(Xe[:, 1], np.cos(X[:, 1]))
+    assert np.allclose(Xe[:, 2], np.sin(X[:, 1]))
+    assert np.allclose(Xe[:, 3], np.cos(X[:, 2]))
+    assert np.allclose(Xe[:, 4], np.sin(X[:, 2]))


### PR DESCRIPTION
## Summary
- extend trig expansion to return original column mapping
- propagate mapping metadata in universal metric/embedding
- test trig expansion index mapping

## Testing
- `pytest tests/test_trig_expand_mapping.py -q`
- `pytest -q` *(fails: FileNotFoundError: [Errno 2] No such file or directory: 'output/msm_analysis'; ImportError: PDBFixer is required...)*
- `tox -e py311 -q` *(fails: py311: SKIP (0.00 seconds))*


------
https://chatgpt.com/codex/tasks/task_e_68aeed3eaf10832e854ababc91d6c088