### PR TITLE
Add transform plan and application scaffolding

### DIFF
--- a/src/pmarlo/__init__.py
+++ b/src/pmarlo/__init__.py
@@ -17,6 +17,7 @@ from .simulation.simulation import Simulation
 from .utils.msm_utils import candidate_lag_ladder
 from .utils.replica_utils import power_of_two_temperature_ladder
 from .utils.seed import quiet_external_loggers
+from .transform import pm_apply_plan, pm_get_plan
 
 if TYPE_CHECKING:  # Only for type annotations; avoids importing heavy deps at runtime
     from .pipeline import LegacyPipeline as LegacyPipelineType
@@ -58,6 +59,8 @@ __all__ = [
     "Simulation",
     "power_of_two_temperature_ladder",
     "candidate_lag_ladder",
+    "pm_get_plan",
+    "pm_apply_plan",
 ]
 
 if MarkovStateModel is not None:

--- a/src/pmarlo/config.py
+++ b/src/pmarlo/config.py
@@ -1,0 +1,17 @@
+import os
+from dataclasses import dataclass
+
+@dataclass
+class ConfigVar:
+    """Simple configuration helper using environment variables."""
+    env: str
+    default: bool = False
+
+    def get(self) -> bool:
+        val = os.getenv(self.env)
+        if val is None:
+            return self.default
+        return val.lower() not in {"0", "false", "no"}
+
+FES_SMOOTHING = ConfigVar("PMARLO_FES_SMOOTHING", False)
+REORDER_STATES = ConfigVar("PMARLO_REORDER_STATES", False)

--- a/src/pmarlo/transform/__init__.py
+++ b/src/pmarlo/transform/__init__.py
@@ -1,0 +1,25 @@
+from .plan import TransformPlan, TransformStep
+from .planner import get_transform_plan
+from .apply import apply_transform_plan
+
+
+def pm_get_plan(dataset):
+    plan = get_transform_plan(dataset)
+    setattr(dataset, "transform_plan", plan)
+    return dataset
+
+
+def pm_apply_plan(dataset):
+    plan = getattr(dataset, "transform_plan", None)
+    if plan is None:
+        return dataset
+    return apply_transform_plan(dataset, plan)
+
+__all__ = [
+    "TransformPlan",
+    "TransformStep",
+    "get_transform_plan",
+    "apply_transform_plan",
+    "pm_get_plan",
+    "pm_apply_plan",
+]

--- a/src/pmarlo/transform/apply.py
+++ b/src/pmarlo/transform/apply.py
@@ -1,0 +1,25 @@
+from .plan import TransformPlan
+
+
+def smooth_fes(dataset, **kwargs):
+    return dataset
+
+
+def reorder_states(dataset, **kwargs):
+    return dataset
+
+
+def fill_gaps(dataset, **kwargs):
+    return dataset
+
+
+def apply_transform_plan(dataset, plan: TransformPlan):
+    for step in plan.steps:
+        if step.name == "SMOOTH_FES":
+            dataset = smooth_fes(dataset, **step.params)
+        elif step.name == "REORDER_STATES":
+            dataset = reorder_states(dataset, **step.params)
+        elif step.name == "FILL_GAPS":
+            dataset = fill_gaps(dataset, **step.params)
+        # ... add others ...
+    return dataset

--- a/src/pmarlo/transform/plan.py
+++ b/src/pmarlo/transform/plan.py
@@ -1,0 +1,16 @@
+from dataclasses import dataclass
+from typing import Any, Literal
+
+TransformName = Literal[
+    "SMOOTH_FES", "MERGE_BINS", "FILL_GAPS", "GROUP_TOP",
+    "REORDER_STATES", "COARSE_GRAIN_MSM", "CLIP_OUTLIERS"
+]
+
+@dataclass(frozen=True)
+class TransformStep:
+    name: TransformName
+    params: dict[str, Any]
+
+@dataclass(frozen=True)
+class TransformPlan:
+    steps: tuple[TransformStep, ...]

--- a/src/pmarlo/transform/planner.py
+++ b/src/pmarlo/transform/planner.py
@@ -1,0 +1,22 @@
+from .plan import TransformPlan, TransformStep
+from ..config import FES_SMOOTHING, REORDER_STATES
+
+
+def get_transform_plan(dataset) -> TransformPlan:
+    steps: list[TransformStep] = []
+
+    # canonical metadata only
+    shape = getattr(dataset, "output_shape", ())
+
+    # heuristics – use canonical shape, not ad-hoc internals
+    if FES_SMOOTHING.get():
+        steps.append(TransformStep("SMOOTH_FES", {"method": "gaussian", "sigma": 1.0}))
+
+    if REORDER_STATES.get() and len(shape) and shape[0] >= 128:
+        steps.append(TransformStep("REORDER_STATES", {"criterion": "degree"}))
+
+    # demux gap repair only if allowed and gaps detected
+    if getattr(dataset, "has_gaps", False) and getattr(dataset, "metadata", None) and getattr(dataset.metadata, "allow_repair", False):
+        steps.append(TransformStep("FILL_GAPS", {"strategy": "nearest"}))
+
+    return TransformPlan(tuple(steps))


### PR DESCRIPTION
## Summary
- add ConfigVar-based flags and expose transformation plan API
- record planned transform steps based on dataset heuristics and apply them later
- export pm_get_plan and pm_apply_plan helpers at package root

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'pmarlo')*
- `tox -q` *(fails: 7 failed, 140 passed, 3 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68aeef2d0904832eb3469764e3835d24