### PR TITLE
Add Streamlit controls for analysis pipeline options

### DIFF
--- a/example_programs/app_usecase/app/app.py
+++ b/example_programs/app_usecase/app/app.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Dict, List, Sequence
+from typing import Any, Dict, List, Sequence
 
 import pandas as pd
 import streamlit as st
@@ -18,6 +18,11 @@ try:  # Prefer package-relative imports when launched via `streamlit run -m`
         WorkspaceLayout,
     )
     from .plots import plot_fes, plot_msm
+    from .plots.diagnostics import (
+        format_warnings,
+        plot_autocorrelation_curves,
+        plot_canonical_correlations,
+    )
     from pmarlo.transform.build import _sanitize_artifacts
 except ImportError:  # Fallback for `streamlit run app.py`
     import sys
@@ -36,6 +41,11 @@ except ImportError:  # Fallback for `streamlit run app.py`
         WorkspaceLayout,
     )
     from plots import plot_fes, plot_msm  # type: ignore
+    from plots.diagnostics import (  # type: ignore
+        format_warnings,
+        plot_autocorrelation_curves,
+        plot_canonical_correlations,
+    )
     from pmarlo.transform.build import _sanitize_artifacts
 
 
@@ -85,6 +95,79 @@ def _metrics_table(flags: Dict[str, object]) -> pd.DataFrame:
     return pd.DataFrame(rows) if rows else pd.DataFrame({"metric": [], "value": []})
 
 
+def _format_tau_schedule(values: Sequence[int]) -> str:
+    if not values:
+        return ""
+    return ", ".join(str(int(v)) for v in values)
+
+
+def _parse_tau_schedule(raw: str) -> List[int]:
+    cleaned = raw.replace(";", ",")
+    values: List[int] = []
+    for token in cleaned.split(","):
+        token = token.strip()
+        if not token:
+            continue
+        try:
+            val = int(token)
+        except ValueError as exc:  # pragma: no cover - defensive parsing
+            raise ValueError(f"Invalid tau value '{token}'") from exc
+        if val <= 0:
+            raise ValueError("Tau values must be positive integers.")
+        values.append(val)
+    if not values:
+        raise ValueError("Provide at least one tau value.")
+    return sorted(set(values))
+
+
+def _update_state(**kwargs: Any) -> None:
+    for key, value in kwargs.items():
+        st.session_state[key] = value
+
+
+def _apply_training_config_to_state(cfg: TrainingConfig) -> None:
+    bins = dict(cfg.bins or {})
+    hidden_str = ", ".join(str(int(h)) for h in cfg.hidden)
+    _update_state(
+        train_lag=int(cfg.lag),
+        train_bins_rg=int(bins.get("Rg", 64)),
+        train_bins_rmsd=int(bins.get("RMSD_ref", 64)),
+        train_seed=int(cfg.seed),
+        train_max_epochs=int(cfg.max_epochs),
+        train_patience=int(cfg.early_stopping),
+        train_temperature=float(cfg.temperature),
+        train_hidden_layers=hidden_str or "128,128",
+        train_tau_schedule=_format_tau_schedule(cfg.tau_schedule),
+        train_val_tau=int(cfg.val_tau),
+        train_epochs_per_tau=int(cfg.epochs_per_tau),
+    )
+
+
+def _apply_analysis_config_to_state(cfg: BuildConfig) -> None:
+    bins = dict(cfg.bins or {})
+    if isinstance(cfg.fes_bandwidth, (int, float)):
+        bw_value = f"{float(cfg.fes_bandwidth):g}"
+    else:
+        bw_value = str(cfg.fes_bandwidth)
+    mode = str(cfg.reweight_mode)
+    mode_norm = mode.upper() if mode.upper() in {"MBAR", "TRAM"} else mode.lower()
+    _update_state(
+        analysis_lag=int(cfg.lag),
+        analysis_bins_rg=int(bins.get("Rg", 72)),
+        analysis_bins_rmsd=int(bins.get("RMSD_ref", 72)),
+        analysis_seed=int(cfg.seed),
+        analysis_temperature=float(cfg.temperature),
+        analysis_learn_cv=bool(cfg.learn_cv),
+        analysis_apply_whitening=bool(cfg.apply_cv_whitening),
+        analysis_cluster_mode=str(cfg.cluster_mode),
+        analysis_n_microstates=int(cfg.n_microstates),
+        analysis_reweight_mode=mode_norm,
+        analysis_fes_method=str(cfg.fes_method),
+        analysis_fes_bandwidth=bw_value,
+        analysis_min_count_per_bin=int(cfg.fes_min_count_per_bin),
+    )
+
+
 def _show_build_outputs(artifact: BuildArtifact | TrainingResult) -> None:
     br = artifact.build_result
     col1, col2 = st.columns(2)
@@ -106,6 +189,23 @@ def _show_build_outputs(artifact: BuildArtifact | TrainingResult) -> None:
         st.write("Messages:")
         for msg in br.messages:
             st.write(f"- {msg}")
+    diagnostics = getattr(br, "diagnostics", None)
+    if isinstance(diagnostics, dict) and diagnostics:
+        st.subheader("Diagnostics")
+        diag_cols = st.columns(2)
+        with diag_cols[0]:
+            fig_diag = plot_canonical_correlations(diagnostics)
+            st.pyplot(fig_diag, clear_figure=True, width="stretch")
+        with diag_cols[1]:
+            fig_auto = plot_autocorrelation_curves(diagnostics)
+            st.pyplot(fig_auto, clear_figure=True, width="stretch")
+        diag_mass = diagnostics.get("diag_mass")
+        if isinstance(diag_mass, (int, float)):
+            st.metric("MSM diagonal mass", f"{float(diag_mass):.3f}")
+        warnings = format_warnings(diagnostics)
+        if warnings:
+            for msg in warnings:
+                st.warning(msg)
 
 
 def _render_deeptica_summary(summary: Dict[str, object]) -> None:
@@ -154,6 +254,16 @@ def _ensure_session_defaults() -> None:
     ):
         st.session_state.setdefault(key, None)
     st.session_state.setdefault(_RUN_PENDING, False)
+    st.session_state.setdefault("train_hidden_layers", "128,128")
+    st.session_state.setdefault("train_tau_schedule", "2,5,10,20")
+    st.session_state.setdefault("train_val_tau", 20)
+    st.session_state.setdefault("train_epochs_per_tau", 15)
+    st.session_state.setdefault("analysis_cluster_mode", "kmeans")
+    st.session_state.setdefault("analysis_n_microstates", 150)
+    st.session_state.setdefault("analysis_reweight_mode", "MBAR")
+    st.session_state.setdefault("analysis_fes_method", "kde")
+    st.session_state.setdefault("analysis_fes_bandwidth", "scott")
+    st.session_state.setdefault("analysis_min_count_per_bin", 1)
 
 
 def main() -> None:
@@ -453,35 +563,64 @@ def main() -> None:
             )
             hidden = st.text_input(
                 "Hidden layer widths",
-                value="128,128",
+                value=st.session_state.get("train_hidden_layers", "128,128"),
                 help="Comma-separated integers for the Deep-TICA network.",
                 key="train_hidden_layers",
+            )
+            col_tau, col_val, col_ep = st.columns(3)
+            tau_raw = col_tau.text_input(
+                "Tau schedule (steps)",
+                value=st.session_state.get("train_tau_schedule", "2,5,10,20"),
+                key="train_tau_schedule",
+            )
+            val_tau = col_val.number_input(
+                "Validation tau (steps)",
+                min_value=1,
+                value=int(st.session_state.get("train_val_tau", 20)),
+                step=1,
+                key="train_val_tau",
+            )
+            epochs_per_tau = col_ep.number_input(
+                "Epochs per tau",
+                min_value=1,
+                value=int(st.session_state.get("train_epochs_per_tau", 15)),
+                step=1,
+                key="train_epochs_per_tau",
             )
             hidden_layers = tuple(int(v.strip()) for v in hidden.split(",") if v.strip()) or (128, 128)
             disabled = len(selected_paths) == 0
             if st.button("Train Deep-TICA model", type="primary", disabled=disabled, key="train_button"):
                 try:
-                    train_cfg = TrainingConfig(
-                        lag=int(lag),
-                        bins={"Rg": int(bins_rg), "RMSD_ref": int(bins_rmsd)},
-                        seed=int(seed),
-                        temperature=float(temperature),
-                        max_epochs=int(max_epochs),
-                        early_stopping=int(patience),
-                        hidden=hidden_layers,
-                    )
-                    result = backend.train_model(selected_paths, train_cfg)
-                    st.session_state[_LAST_TRAIN] = result
-                    st.session_state[_LAST_TRAIN_CONFIG] = train_cfg
-                    st.success(
-                        f"Model stored at {result.bundle_path.name} (hash {result.dataset_hash})."
-                    )
-                    _show_build_outputs(result)
-                    summary = result.build_result.artifacts.get("mlcv_deeptica") if result.build_result else None
-                    if summary:
-                        _render_deeptica_summary(summary)
-                except Exception as exc:
-                    st.error(f"Training failed: {exc}")
+                    tau_values = _parse_tau_schedule(tau_raw)
+                except ValueError as exc:
+                    st.error(f"Tau schedule error: {exc}")
+                else:
+                    try:
+                        train_cfg = TrainingConfig(
+                            lag=int(lag),
+                            bins={"Rg": int(bins_rg), "RMSD_ref": int(bins_rmsd)},
+                            seed=int(seed),
+                            temperature=float(temperature),
+                            max_epochs=int(max_epochs),
+                            early_stopping=int(patience),
+                            hidden=hidden_layers,
+                            tau_schedule=tuple(tau_values),
+                            val_tau=int(val_tau),
+                            epochs_per_tau=int(epochs_per_tau),
+                        )
+                        result = backend.train_model(selected_paths, train_cfg)
+                        st.session_state[_LAST_TRAIN] = result
+                        st.session_state[_LAST_TRAIN_CONFIG] = train_cfg
+                        _apply_training_config_to_state(train_cfg)
+                        st.success(
+                            f"Model stored at {result.bundle_path.name} (hash {result.dataset_hash})."
+                        )
+                        _show_build_outputs(result)
+                        summary = result.build_result.artifacts.get("mlcv_deeptica") if result.build_result else None
+                        if summary:
+                            _render_deeptica_summary(summary)
+                    except Exception as exc:
+                        st.error(f"Training failed: {exc}")
 
         models = backend.list_models()
         if models:
@@ -506,7 +645,9 @@ def main() -> None:
                     if loaded is not None:
                         st.session_state[_LAST_TRAIN] = loaded
                         try:
-                            st.session_state[_LAST_TRAIN_CONFIG] = backend.training_config_from_entry(models[int(selected_idx)])
+                            cfg_loaded = backend.training_config_from_entry(models[int(selected_idx)])
+                            st.session_state[_LAST_TRAIN_CONFIG] = cfg_loaded
+                            _apply_training_config_to_state(cfg_loaded)
                         except Exception:
                             pass
                         st.success(f"Loaded model {loaded.bundle_path.name}.")
@@ -547,6 +688,11 @@ def main() -> None:
                     loaded = backend.load_analysis_bundle(int(selected_idx))
                     if loaded is not None:
                         st.session_state[_LAST_BUILD] = loaded
+                        try:
+                            cfg_loaded = backend.build_config_from_entry(builds[int(selected_idx)])
+                            _apply_analysis_config_to_state(cfg_loaded)
+                        except Exception:
+                            pass
                         st.success(f"Loaded bundle {loaded.bundle_path.name}.")
                         _show_build_outputs(loaded)
                         summary = loaded.build_result.artifacts.get("mlcv_deeptica") if loaded.build_result else None
@@ -589,6 +735,52 @@ def main() -> None:
                 value=True,
                 key="analysis_apply_whitening",
             )
+            col_cluster, col_micro = st.columns(2)
+            cluster_mode = col_cluster.selectbox(
+                "Discretization mode",
+                options=["kmeans", "grid"],
+                index=(0 if str(st.session_state.get("analysis_cluster_mode", "kmeans")).lower() != "grid" else 1),
+                key="analysis_cluster_mode",
+            )
+            n_microstates = col_micro.number_input(
+                "Number of microstates",
+                min_value=2,
+                value=int(st.session_state.get("analysis_n_microstates", 150)),
+                step=1,
+                key="analysis_n_microstates",
+            )
+            reweight_default = str(st.session_state.get("analysis_reweight_mode", "MBAR"))
+            reweight_index = 0
+            if reweight_default.upper() == "TRAM":
+                reweight_index = 1
+            elif reweight_default.lower() == "none":
+                reweight_index = 2
+            reweight_mode = st.selectbox(
+                "Reweighting mode",
+                options=["MBAR", "TRAM", "none"],
+                index=reweight_index,
+                key="analysis_reweight_mode",
+            )
+            col_fes_method, col_bw, col_min = st.columns(3)
+            fes_method = col_fes_method.selectbox(
+                "FES method",
+                options=["kde", "grid"],
+                index=(0 if str(st.session_state.get("analysis_fes_method", "kde")).lower() != "grid" else 1),
+                key="analysis_fes_method",
+            )
+            fes_bandwidth = col_bw.text_input(
+                "FES bandwidth",
+                value=str(st.session_state.get("analysis_fes_bandwidth", "scott")),
+                help="Use 'scott', 'silverman', or a positive float (only for KDE).",
+                key="analysis_fes_bandwidth",
+            )
+            min_count_per_bin = col_min.number_input(
+                "Min count per bin",
+                min_value=0,
+                value=int(st.session_state.get("analysis_min_count_per_bin", 1)),
+                step=1,
+                key="analysis_min_count_per_bin",
+            )
             deeptica_params = None
             if learn_cv:
                 reuse = st.checkbox(
@@ -620,6 +812,16 @@ def main() -> None:
             disabled = len(selected_paths) == 0
             if st.button("Build MSM/FES bundle", type="primary", disabled=disabled, key="analysis_build_button"):
                 try:
+                    bw_clean = fes_bandwidth.strip()
+                    try:
+                        bandwidth_val: str | float = float(bw_clean) if bw_clean else "scott"
+                    except ValueError:
+                        bandwidth_val = bw_clean or "scott"
+                    reweight_norm = str(reweight_mode)
+                    if reweight_norm.upper() in {"MBAR", "TRAM"}:
+                        reweight_final = reweight_norm.upper()
+                    else:
+                        reweight_final = "none"
                     build_cfg = BuildConfig(
                         lag=int(lag),
                         bins={"Rg": int(bins_rg), "RMSD_ref": int(bins_rmsd)},
@@ -629,9 +831,16 @@ def main() -> None:
                         deeptica_params=deeptica_params,
                         notes={"source": "app_usecase"},
                         apply_cv_whitening=bool(apply_whitening),
+                        cluster_mode=str(cluster_mode),
+                        n_microstates=int(n_microstates),
+                        reweight_mode=reweight_final,
+                        fes_method=str(fes_method),
+                        fes_bandwidth=bandwidth_val,
+                        fes_min_count_per_bin=int(min_count_per_bin),
                     )
                     artifact = backend.build_analysis(selected_paths, build_cfg)
                     st.session_state[_LAST_BUILD] = artifact
+                    _apply_analysis_config_to_state(build_cfg)
                     st.success(
                         f"Bundle {artifact.bundle_path.name} written (hash {artifact.dataset_hash})."
                     )

--- a/example_programs/app_usecase/app/plots/__init__.py
+++ b/example_programs/app_usecase/app/plots/__init__.py
@@ -1,21 +1,17 @@
-from __future__ import annotations
-
-"""Matplotlib helpers to visualize MSM and FES results.
-
-Only matplotlib is used (no seaborn). Functions return figures.
-"""
+"""Matplotlib helpers to visualize MSM and FES results."""
 
 from typing import Any
 
-import numpy as np
 import matplotlib.pyplot as plt
+import numpy as np
+
+
+__all__ = ["plot_msm", "plot_fes"]
 
 
 def plot_msm(T: np.ndarray | None, pi: np.ndarray | None) -> plt.Figure:
-    """Render a transition matrix heatmap with a stationary distribution bar.
+    """Render a transition matrix heatmap with a stationary distribution bar."""
 
-    If inputs are missing/empty, returns a small figure with a message.
-    """
     if T is None or pi is None or T.size == 0 or pi.size == 0:
         fig, ax = plt.subplots(figsize=(5, 3))
         ax.axis("off")
@@ -46,17 +42,14 @@ def plot_msm(T: np.ndarray | None, pi: np.ndarray | None) -> plt.Figure:
 
 
 def plot_fes(fes: Any | None) -> plt.Figure:
-    """Render a 2D FES contour if present.
+    """Render a 2D FES contour if present."""
 
-    Accepts a pmarlo.markov_state_model.free_energy.FESResult or a dict with the same fields.
-    """
     if fes is None:
         fig, ax = plt.subplots(figsize=(5, 3))
         ax.axis("off")
         ax.text(0.5, 0.5, "No FES available", ha="center", va="center")
         return fig
 
-    # Support dataclass or dict
     try:
         F = np.asarray(getattr(fes, "F"))
         xedges = np.asarray(getattr(fes, "xedges"))
@@ -73,6 +66,7 @@ def plot_fes(fes: Any | None) -> plt.Figure:
     Yc = 0.5 * (yedges[:-1] + yedges[1:])
     cs = ax.contourf(Xc, Yc, F.T, levels=20, cmap="magma")
     fig.colorbar(cs, ax=ax, label="F (kJ/mol)")
+
     names = None
     try:
         names = meta.get("names") or ()
@@ -84,9 +78,8 @@ def plot_fes(fes: Any | None) -> plt.Figure:
     else:
         ax.set_xlabel("cv1")
         ax.set_ylabel("cv2")
-    # Quality annotation if sparse sampling
+
     try:
-        frac = None
         frac = meta.get("empty_bins_fraction") if isinstance(meta, dict) else None
         if frac is not None and float(frac) > 0.30:
             ax.text(
@@ -100,7 +93,6 @@ def plot_fes(fes: Any | None) -> plt.Figure:
                 fontsize=10,
                 fontweight="bold",
             )
-        # Show adaptive smoothing banner when present
         if isinstance(meta, dict) and meta.get("sparse_banner"):
             ax.text(
                 0.5,
@@ -115,5 +107,6 @@ def plot_fes(fes: Any | None) -> plt.Figure:
             )
     except Exception:
         pass
+
     ax.set_title("Free Energy Surface")
     return fig

--- a/example_programs/app_usecase/app/plots/diagnostics.py
+++ b/example_programs/app_usecase/app/plots/diagnostics.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+"""Plot helpers for diagnostic metrics displayed in the Streamlit app."""
+
+from typing import Any, Dict
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+__all__ = [
+    "plot_canonical_correlations",
+    "plot_autocorrelation_curves",
+    "format_warnings",
+]
+
+
+def plot_canonical_correlations(diagnostics: Dict[str, Any]) -> plt.Figure:
+    """Visualise canonical correlations between inputs and CVs."""
+
+    data = diagnostics.get("canonical_correlation", {}) if diagnostics else {}
+    if not data:
+        fig, ax = plt.subplots(figsize=(5, 3))
+        ax.axis("off")
+        ax.text(0.5, 0.5, "No canonical correlation data", ha="center", va="center")
+        return fig
+
+    fig, ax = plt.subplots(figsize=(6, 4))
+    for split, values in sorted(data.items()):
+        if not values:
+            continue
+        x = np.arange(1, len(values) + 1, dtype=float)
+        ax.plot(x, values, marker="o", label=str(split))
+    ax.set_xlabel("Component")
+    ax.set_ylabel("Canonical correlation")
+    ax.set_ylim(0.0, 1.05)
+    ax.set_title("Canonical correlation (inputs vs CVs)")
+    if len(data) > 1:
+        ax.legend()
+    ax.grid(True, alpha=0.3)
+    return fig
+
+
+def plot_autocorrelation_curves(diagnostics: Dict[str, Any]) -> plt.Figure:
+    """Plot autocorrelation decay curves for each split."""
+
+    entries = diagnostics.get("autocorrelation", {}) if diagnostics else {}
+    if not entries:
+        fig, ax = plt.subplots(figsize=(5, 3))
+        ax.axis("off")
+        ax.text(0.5, 0.5, "No autocorrelation data", ha="center", va="center")
+        return fig
+
+    fig, ax = plt.subplots(figsize=(6, 4))
+    for split, payload in sorted(entries.items()):
+        taus = np.asarray(payload.get("taus", []), dtype=float)
+        values = np.asarray(payload.get("values", []), dtype=float)
+        if taus.size == 0 or values.size == 0:
+            continue
+        ax.plot(taus, values, marker="o", label=str(split))
+    ax.set_xlabel("Lag τ")
+    ax.set_ylabel("ρ(τ)")
+    ax.set_ylim(-0.05, 1.05)
+    ax.set_title("CV autocorrelation")
+    if len(entries) > 1:
+        ax.legend()
+    ax.grid(True, alpha=0.3)
+    return fig
+
+
+def format_warnings(diagnostics: Dict[str, Any]) -> list[str]:
+    """Extract warning messages for display."""
+
+    if not diagnostics:
+        return []
+    warnings = diagnostics.get("warnings")
+    if isinstance(warnings, list):
+        return [str(msg) for msg in warnings]
+    return []

--- a/src/pmarlo/analysis/__init__.py
+++ b/src/pmarlo/analysis/__init__.py
@@ -1,11 +1,15 @@
 """Utilities for downstream analysis of learned collective variables."""
 
 from .project_cv import apply_whitening_from_metadata
-from .msm import ensure_msm_inputs_whitened
-from .fes import ensure_fes_inputs_whitened
+from .msm import ensure_msm_inputs_whitened, prepare_msm_discretization
+from .fes import compute_weighted_fes, ensure_fes_inputs_whitened
+from .diagnostics import compute_diagnostics
 
 __all__ = [
     "apply_whitening_from_metadata",
     "ensure_msm_inputs_whitened",
+    "prepare_msm_discretization",
     "ensure_fes_inputs_whitened",
+    "compute_weighted_fes",
+    "compute_diagnostics",
 ]

--- a/src/pmarlo/analysis/diagnostics.py
+++ b/src/pmarlo/analysis/diagnostics.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Mapping, MutableMapping, Sequence
+
+import numpy as np
+
+from .discretize import _coerce_array, _normalise_splits
+from .project_cv import apply_whitening_from_metadata
+
+logger = logging.getLogger(__name__)
+
+DatasetLike = Mapping[str, Any] | MutableMapping[str, Any]
+_TAU_SEQUENCE: tuple[int, ...] = (2, 5, 10, 20, 40)
+
+
+def _extract_optional_inputs(split: Mapping[str, Any]) -> np.ndarray | None:
+    candidate_keys = (
+        "inputs",
+        "raw",
+        "raw_inputs",
+        "raw_features",
+        "features",
+        "input_features",
+    )
+    for key in candidate_keys:
+        value = split.get(key)
+        if value is None:
+            continue
+        arr = np.asarray(value, dtype=np.float64)
+        if arr.ndim != 2:
+            continue
+        if arr.shape[0] == 0 or not np.isfinite(arr).all():
+            continue
+        return arr
+    return None
+
+
+def _canonical_correlations(X: np.ndarray, Y: np.ndarray, *, regularisation: float = 1e-8) -> list[float]:
+    n = min(X.shape[0], Y.shape[0])
+    if n < 2:
+        return []
+    X = X[:n]
+    Y = Y[:n]
+    Xc = X - np.mean(X, axis=0, keepdims=True)
+    Yc = Y - np.mean(Y, axis=0, keepdims=True)
+    Sxx = (Xc.T @ Xc) / max(n - 1, 1)
+    Syy = (Yc.T @ Yc) / max(n - 1, 1)
+    Sxy = (Xc.T @ Yc) / max(n - 1, 1)
+
+    def _inv_sqrt(mat: np.ndarray) -> np.ndarray:
+        eigvals, eigvecs = np.linalg.eigh(mat + regularisation * np.eye(mat.shape[0]))
+        eigvals = np.clip(eigvals, a_min=regularisation, a_max=None)
+        inv_root = eigvecs @ np.diag(1.0 / np.sqrt(eigvals)) @ eigvecs.T
+        return inv_root
+
+    try:
+        inv_sqrt_x = _inv_sqrt(Sxx)
+        inv_sqrt_y = _inv_sqrt(Syy)
+    except np.linalg.LinAlgError:
+        return []
+    M = inv_sqrt_x @ Sxy @ inv_sqrt_y
+    try:
+        _, s, _ = np.linalg.svd(M, full_matrices=False)
+    except np.linalg.LinAlgError:
+        return []
+    s = np.clip(s, 0.0, 1.0)
+    return [float(val) for val in s]
+
+
+def _autocorrelation_curve(X: np.ndarray, taus: Sequence[int]) -> list[float]:
+    if X.shape[0] < 2:
+        return [float("nan") for _ in taus]
+    Xc = X - np.mean(X, axis=0, keepdims=True)
+    curve: list[float] = []
+    for tau in taus:
+        if tau <= 0 or tau >= Xc.shape[0]:
+            curve.append(float("nan"))
+            continue
+        a = Xc[:-tau]
+        b = Xc[tau:]
+        numerator = np.sum(a * b, axis=0)
+        denominator = np.sum(a * a, axis=0)
+        with np.errstate(divide="ignore", invalid="ignore"):
+            rho = np.divide(numerator, denominator, out=np.zeros_like(numerator), where=denominator > 0)
+        if rho.size == 0:
+            curve.append(float("nan"))
+        else:
+            finite = rho[np.isfinite(rho)]
+            value = float(np.mean(finite)) if finite.size else float("nan")
+            curve.append(value)
+    return curve
+
+
+def compute_diagnostics(
+    dataset: DatasetLike,
+    *,
+    diag_mass: float | None = None,
+    taus: Sequence[int] = _TAU_SEQUENCE,
+) -> Dict[str, Any]:
+    """Compute triviality/stability diagnostics for downstream reporting."""
+
+    splits = _normalise_splits(dataset)
+    canonical: Dict[str, list[float]] = {}
+    autocorr: Dict[str, Dict[str, Any]] = {}
+    warnings: list[str] = []
+
+    for name, split in splits.items():
+        try:
+            X = _coerce_array(split)
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.debug("Skipping diagnostic split %s: %s", name, exc)
+            continue
+        metadata = None
+        if isinstance(split, Mapping):
+            metadata = split.get("meta")
+        whitened, _ = apply_whitening_from_metadata(X, metadata)
+
+        inputs = None
+        if isinstance(split, Mapping):
+            inputs = _extract_optional_inputs(split)
+        if inputs is not None:
+            if inputs.shape[0] != whitened.shape[0]:
+                length = min(inputs.shape[0], whitened.shape[0])
+                inputs = inputs[:length]
+                whitened = whitened[:length]
+            corr = _canonical_correlations(inputs, whitened)
+            if corr:
+                canonical[name] = corr
+                if corr and min(corr) > 0.95:
+                    msg = f"{name}: CVs reparametrize inputs"
+                    warnings.append(msg)
+                    logger.warning(msg)
+        curve = _autocorrelation_curve(whitened, taus)
+        autocorr[name] = {"taus": list(taus), "values": curve}
+        if len(curve) >= 4 and np.isfinite(curve[0]) and np.isfinite(curve[3]):
+            if abs(curve[0] - curve[3]) < 0.05:
+                msg = f"{name}: CV autocorrelation flat across lags"
+                warnings.append(msg)
+                logger.warning(msg)
+
+    if diag_mass is not None and np.isfinite(diag_mass) and diag_mass > 0.95:
+        msg = f"MSM diagonal mass high ({diag_mass:.3f})"
+        warnings.append(msg)
+        logger.warning(msg)
+
+    return {
+        "canonical_correlation": canonical,
+        "autocorrelation": autocorr,
+        "diag_mass": float(diag_mass) if diag_mass is not None else None,
+        "taus": list(taus),
+        "warnings": warnings,
+    }

--- a/src/pmarlo/analysis/discretize.py
+++ b/src/pmarlo/analysis/discretize.py
@@ -1,0 +1,328 @@
+"""Discretisation helpers for MSM analysis of learned collective variables."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, Mapping, MutableMapping, Sequence
+
+import logging
+
+import numpy as np
+
+from sklearn.cluster import KMeans, MiniBatchKMeans
+
+
+logger = logging.getLogger("pmarlo")
+
+
+DatasetLike = Mapping[str, Any] | MutableMapping[str, Any]
+
+
+@dataclass(slots=True)
+class MSMDiscretizationResult:
+    """Container with the outcome of MSM discretisation."""
+
+    assignments: Dict[str, np.ndarray]
+    centers: np.ndarray | None
+    counts: np.ndarray
+    transition_matrix: np.ndarray
+    lag_time: int
+    diag_mass: float
+    cluster_mode: str
+
+
+def _looks_like_split(value: Any) -> bool:
+    if isinstance(value, (Mapping, MutableMapping)):
+        candidate = value.get("X")
+        if candidate is None:
+            return False
+        arr = np.asarray(candidate)
+    elif hasattr(value, "X"):
+        arr = np.asarray(getattr(value, "X"))
+    else:
+        arr = np.asarray(value)
+
+    if arr.ndim != 2 or arr.shape[0] == 0 or arr.shape[1] == 0:
+        return False
+    return np.isfinite(arr).all()
+
+
+def _normalise_splits(dataset: DatasetLike) -> Dict[str, Any]:
+    splits: Dict[str, Any] = {}
+
+    maybe_splits = dataset.get("splits") if isinstance(dataset, Mapping) else None
+    if isinstance(maybe_splits, Mapping):
+        for name, value in maybe_splits.items():
+            if _looks_like_split(value):
+                splits[str(name)] = value
+
+    if not splits:
+        for name, value in dataset.items():  # type: ignore[assignment]
+            if str(name).startswith("__"):
+                continue
+            if _looks_like_split(value):
+                splits[str(name)] = value
+
+    if not splits and _looks_like_split(dataset):
+        splits["all"] = dataset
+
+    if not splits:
+        raise ValueError("No continuous CV splits found in dataset")
+
+    return splits
+
+
+def _coerce_array(obj: Any, *, copy: bool = False) -> np.ndarray:
+    if isinstance(obj, (Mapping, MutableMapping)):
+        arr = obj.get("X")
+    elif hasattr(obj, "X"):
+        arr = getattr(obj, "X")
+    else:
+        arr = obj
+
+    array = np.array(arr, dtype=np.float64, copy=copy)
+    if array.ndim != 2:
+        raise ValueError(f"Expected 2D array, got shape {array.shape}")
+    if array.shape[0] == 0:
+        raise ValueError("Split is empty")
+    return array
+
+
+def _coerce_weights(weights: Any, n_frames: int, split_name: str) -> np.ndarray | None:
+    if weights is None:
+        return None
+
+    candidate: Any
+    if isinstance(weights, Mapping):
+        candidate = weights.get(split_name)
+    else:
+        candidate = weights
+
+    if candidate is None:
+        return None
+
+    arr = np.asarray(candidate, dtype=np.float64).reshape(-1)
+    if arr.shape[0] != n_frames:
+        raise ValueError(
+            f"Frame weights for split '{split_name}' have length {arr.shape[0]},"
+            f" expected {n_frames}",
+        )
+    return arr
+
+
+def _minibatch_threshold(n_frames: int, n_features: int) -> bool:
+    return n_frames * n_features >= 5_000_000
+
+
+class _KMeansDiscretizer:
+    def __init__(
+        self,
+        n_states: int,
+        *,
+        random_state: int | None = None,
+    ) -> None:
+        self.n_states = int(n_states)
+        self.random_state = random_state
+        self.model: KMeans | MiniBatchKMeans | None = None
+
+    def fit(self, X: np.ndarray) -> None:
+        if _minibatch_threshold(X.shape[0], X.shape[1]):
+            self.model = MiniBatchKMeans(
+                n_clusters=self.n_states,
+                random_state=self.random_state,
+            )
+        else:
+            self.model = KMeans(
+                n_clusters=self.n_states,
+                random_state=self.random_state,
+                n_init=10,
+            )
+        self.model.fit(X)
+
+    def transform(self, X: np.ndarray) -> np.ndarray:
+        if self.model is None:
+            raise RuntimeError("Discretizer has not been fitted")
+        labels = self.model.predict(X)
+        return labels.astype(np.int32, copy=False)
+
+    @property
+    def centers(self) -> np.ndarray | None:
+        if self.model is None:
+            return None
+        centers = getattr(self.model, "cluster_centers_", None)
+        if centers is None:
+            return None
+        return np.asarray(centers, dtype=np.float64)
+
+
+class _GridDiscretizer:
+    def __init__(self, *, target_states: int) -> None:
+        self.target_states = max(int(target_states), 1)
+        self.edges: list[np.ndarray] = []
+        self.mapping: Dict[tuple[int, ...], int] = {}
+
+    def fit(self, X: np.ndarray) -> None:
+        n_features = X.shape[1]
+        bins_per_dim = max(int(round(self.target_states ** (1.0 / n_features))), 1)
+        self.edges = []
+        for col in range(n_features):
+            data = X[:, col]
+            lo = float(np.min(data))
+            hi = float(np.max(data))
+            if not np.isfinite(lo) or not np.isfinite(hi):
+                raise ValueError("Non-finite values encountered while building grid")
+            if lo == hi:
+                lo -= 0.5
+                hi += 0.5
+            self.edges.append(np.linspace(lo, hi, bins_per_dim + 1, dtype=np.float64))
+        combos = self._compute_indices(X)
+        for combo in combos:
+            key = tuple(int(x) for x in combo)
+            if key not in self.mapping:
+                self.mapping[key] = len(self.mapping)
+
+    def _compute_indices(self, X: np.ndarray) -> np.ndarray:
+        indices = []
+        for dim, edges in enumerate(self.edges):
+            idx = np.clip(np.digitize(X[:, dim], edges) - 1, 0, len(edges) - 2)
+            indices.append(idx)
+        return np.vstack(indices).T
+
+    def transform(self, X: np.ndarray) -> np.ndarray:
+        if not self.edges:
+            raise RuntimeError("Discretizer has not been fitted")
+        combos = self._compute_indices(X)
+        labels = np.empty(combos.shape[0], dtype=np.int32)
+        for i, combo in enumerate(combos):
+            key = tuple(int(x) for x in combo)
+            state = self.mapping.get(key)
+            if state is None:
+                state = len(self.mapping)
+                self.mapping[key] = state
+            labels[i] = state
+        return labels
+
+    @property
+    def centers(self) -> np.ndarray | None:
+        if not self.edges:
+            return None
+        mesh = np.meshgrid(*[
+            (edges[:-1] + edges[1:]) / 2.0 for edges in self.edges
+        ], indexing="ij")
+        coords = np.stack([m.ravel() for m in mesh], axis=1)
+        return coords
+
+
+def _iter_segments(length: int) -> Iterable[tuple[int, int]]:
+    yield 0, length
+
+
+def _weighted_counts(
+    labels: np.ndarray,
+    *,
+    n_states: int,
+    lag_time: int,
+    weights: np.ndarray | None = None,
+) -> np.ndarray:
+    counts = np.zeros((n_states, n_states), dtype=np.float64)
+    if labels.size == 0 or lag_time <= 0:
+        return counts
+
+    for start, stop in _iter_segments(labels.size):
+        length = stop - start
+        if length <= lag_time:
+            continue
+        src = labels[start : stop - lag_time]
+        dst = labels[start + lag_time : stop]
+        if weights is not None:
+            w = weights[start : stop - lag_time]
+            np.add.at(counts, (src, dst), w)
+        else:
+            np.add.at(counts, (src, dst), 1.0)
+    return counts
+
+
+def _normalise_counts(C: np.ndarray) -> np.ndarray:
+    row_sums = C.sum(axis=1, keepdims=True)
+    with np.errstate(divide="ignore", invalid="ignore"):
+        T = np.divide(C, row_sums, out=np.zeros_like(C), where=row_sums > 0)
+    return T
+
+
+def discretize_dataset(
+    dataset: DatasetLike,
+    *,
+    cluster_mode: str = "kmeans",
+    n_microstates: int = 150,
+    lag_time: int = 1,
+    frame_weights: Mapping[str, Sequence[float]] | Sequence[float] | np.ndarray | None = None,
+    random_state: int | None = None,
+) -> MSMDiscretizationResult:
+    """Discretise continuous CVs into microstates and build MSM statistics."""
+
+    if lag_time < 1:
+        raise ValueError("lag_time must be >= 1")
+
+    splits = _normalise_splits(dataset)
+    discretizer: _KMeansDiscretizer | _GridDiscretizer
+
+    train_key = "train" if "train" in splits else next(iter(splits))
+    train_data = _coerce_array(splits[train_key])
+
+    if cluster_mode == "kmeans":
+        discretizer = _KMeansDiscretizer(n_microstates, random_state=random_state)
+    elif cluster_mode == "grid":
+        discretizer = _GridDiscretizer(target_states=n_microstates)
+    else:
+        raise ValueError("cluster_mode must be 'kmeans' or 'grid'")
+
+    discretizer.fit(train_data)
+
+    assignments: Dict[str, np.ndarray] = {}
+    max_state = -1
+    for name, split in splits.items():
+        X = _coerce_array(split)
+        labels = discretizer.transform(X)
+        assignments[name] = labels
+        if labels.size:
+            max_state = max(max_state, int(labels.max()))
+
+    n_states = max_state + 1 if max_state >= 0 else 0
+
+    train_labels = assignments[train_key]
+    weights = _coerce_weights(frame_weights, train_labels.size, train_key)
+
+    counts = _weighted_counts(
+        train_labels,
+        n_states=n_states,
+        lag_time=lag_time,
+        weights=weights,
+    )
+
+    transition = _normalise_counts(counts)
+
+    if n_states:
+        diag_mass = float(np.trace(transition) / n_states)
+    else:
+        diag_mass = float("nan")
+
+    if np.isfinite(diag_mass) and diag_mass > 0.95:
+        logger.warning("MSM diagonal mass high (%.3f)", diag_mass)
+
+    zero_states = np.where(counts.sum(axis=1) == 0)[0]
+    if counts.shape[0] and zero_states.size / counts.shape[0] > 0.3:
+        logger.warning(
+            "More than 30%% of the microstates are empty (%d/%d)",
+            zero_states.size,
+            counts.shape[0],
+        )
+
+    return MSMDiscretizationResult(
+        assignments=assignments,
+        centers=discretizer.centers,
+        counts=counts,
+        transition_matrix=transition,
+        lag_time=lag_time,
+        diag_mass=diag_mass,
+        cluster_mode=cluster_mode,
+    )

--- a/src/pmarlo/reweight/__init__.py
+++ b/src/pmarlo/reweight/__init__.py
@@ -1,0 +1,5 @@
+"""Reweighting utilities for MSM and FES analysis."""
+
+from .reweighter import AnalysisReweightMode, Reweighter
+
+__all__ = ["AnalysisReweightMode", "Reweighter"]

--- a/src/pmarlo/reweight/reweighter.py
+++ b/src/pmarlo/reweight/reweighter.py
@@ -1,0 +1,225 @@
+"""Frame reweighting helpers for MSM and FES analysis."""
+
+from __future__ import annotations
+
+"""Reweighting helpers for downstream MSM/FES analysis."""
+
+from dataclasses import dataclass
+from typing import Dict, Mapping, MutableMapping
+
+import math
+import numpy as np
+
+
+_KB_KJ_PER_MOL = 0.00831446261815324
+
+
+AnalysisDataset = Mapping[str, object] | MutableMapping[str, object]
+
+
+class AnalysisReweightMode:
+    """Enumeration of supported analysis reweighting modes."""
+
+    NONE = "none"
+    MBAR = "MBAR"
+    TRAM = "TRAM"
+
+    @classmethod
+    def normalise(cls, value: str | None) -> str:
+        if value is None:
+            return cls.NONE
+        val = str(value).strip().upper()
+        if val == "NONE":
+            return cls.NONE
+        if val == cls.TRAM:
+            return cls.TRAM
+        return cls.MBAR
+
+
+@dataclass(slots=True)
+class _SplitThermo:
+    shard_id: str
+    beta_sim: float
+    energy: np.ndarray | None
+    bias: np.ndarray | None
+    base_weights: np.ndarray | None
+
+    @property
+    def n_frames(self) -> int:
+        if self.energy is not None:
+            return int(self.energy.shape[0])
+        if self.bias is not None:
+            return int(self.bias.shape[0])
+        if self.base_weights is not None:
+            return int(self.base_weights.shape[0])
+        return 0
+
+
+class Reweighter:
+    """Compute per-frame analysis weights relative to a reference temperature."""
+
+    def __init__(self, temperature_ref_K: float) -> None:
+        if not math.isfinite(temperature_ref_K) or temperature_ref_K <= 0:
+            raise ValueError("temperature_ref_K must be a positive finite value")
+        self.temperature_ref_K = float(temperature_ref_K)
+        self.beta_ref = 1.0 / (_KB_KJ_PER_MOL * self.temperature_ref_K)
+        self._cache: Dict[str, np.ndarray] = {}
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def apply(
+        self,
+        dataset: AnalysisDataset,
+        *,
+        mode: str = AnalysisReweightMode.MBAR,
+    ) -> Dict[str, np.ndarray]:
+        """Compute weights for each split and attach them to ``dataset``.
+
+        When thermodynamic information is not available the returned weights are
+        uniform for the respective split.
+        """
+
+        splits = self._extract_splits(dataset)
+        if not splits:
+            raise ValueError("Dataset must expose 'splits' mapping with CV arrays")
+
+        chosen_mode = AnalysisReweightMode.normalise(mode)
+        weights: Dict[str, np.ndarray] = {}
+
+        for split_name, thermo in splits.items():
+            cached = self._cache.get(thermo.shard_id)
+            if cached is not None and cached.shape[0] == thermo.n_frames:
+                w = cached
+            else:
+                w = self._compute_split_weights(thermo, chosen_mode)
+                self._cache[thermo.shard_id] = w
+
+            weights[split_name] = w
+            self._store_split_weights(dataset, split_name, thermo.shard_id, w)
+
+        # Attach convenience mapping for downstream MSM/FES helpers
+        if isinstance(dataset, MutableMapping):
+            dataset.setdefault("frame_weights", {}).update(weights)
+        return weights
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _extract_splits(
+        self, dataset: AnalysisDataset
+    ) -> Dict[str, _SplitThermo]:
+        splits_raw = dataset.get("splits") if isinstance(dataset, Mapping) else None
+        if not isinstance(splits_raw, Mapping):
+            return {}
+
+        splits: Dict[str, _SplitThermo] = {}
+        for name, split in splits_raw.items():
+            shard_id = self._coerce_shard_id(name, split)
+            thermo = _SplitThermo(
+                shard_id=shard_id,
+                beta_sim=self._coerce_beta(split),
+                energy=self._coerce_optional_array(split, "energy"),
+                bias=self._coerce_optional_array(split, "bias"),
+                base_weights=self._coerce_optional_array(split, "weights"),
+            )
+            splits[str(name)] = thermo
+        return splits
+
+    def _coerce_optional_array(
+        self, split: object, key: str
+    ) -> np.ndarray | None:
+        if isinstance(split, Mapping):
+            val = split.get(key)
+        else:
+            val = getattr(split, key, None)
+        if val is None:
+            return None
+        arr = np.asarray(val, dtype=np.float64).reshape(-1)
+        if arr.size == 0:
+            return None
+        return arr
+
+    def _coerce_shard_id(self, name: str, split: object) -> str:
+        candidate = None
+        if isinstance(split, Mapping):
+            meta = split.get("meta")
+            if isinstance(meta, Mapping):
+                candidate = meta.get("shard_id") or meta.get("id")
+            candidate = candidate or split.get("shard_id") or split.get("id")
+        else:
+            candidate = getattr(split, "shard_id", None)
+        if candidate is None:
+            return str(name)
+        return str(candidate)
+
+    def _coerce_beta(self, split: object) -> float:
+        beta = None
+        temp = None
+        if isinstance(split, Mapping):
+            beta = split.get("beta")
+            temp = split.get("temperature_K")
+        else:
+            beta = getattr(split, "beta", None)
+            temp = getattr(split, "temperature_K", None)
+        if beta is not None:
+            beta_val = float(beta)
+            if beta_val > 0 and math.isfinite(beta_val):
+                return beta_val
+        if temp is not None:
+            T = float(temp)
+            if T > 0 and math.isfinite(T):
+                return 1.0 / (_KB_KJ_PER_MOL * T)
+        raise ValueError(
+            "Each split must define beta or temperature_K for reweighting"
+        )
+
+    def _compute_split_weights(
+        self, thermo: _SplitThermo, mode: str
+    ) -> np.ndarray:
+        n_frames = thermo.n_frames
+        if n_frames <= 0:
+            return np.zeros((0,), dtype=np.float64)
+
+        if thermo.energy is None:
+            base = np.ones(n_frames, dtype=np.float64)
+        else:
+            exponent = -(self.beta_ref - thermo.beta_sim) * thermo.energy
+            if thermo.bias is not None:
+                exponent -= self.beta_ref * thermo.bias
+            exponent = np.clip(exponent - np.max(exponent), -700.0, 700.0)
+            base = np.exp(exponent, dtype=np.float64)
+
+        if thermo.base_weights is not None:
+            base = base * thermo.base_weights
+
+        total = float(np.sum(base))
+        if not math.isfinite(total) or total <= 0:
+            base = np.ones(n_frames, dtype=np.float64)
+            total = float(n_frames)
+        weights = base / total
+
+        # ``TRAM`` currently shares the MBAR estimator until multi-ensemble data
+        # becomes available.  The explicit branch is kept to make the behaviour
+        # obvious during debugging and simplifies future upgrades.
+        if mode == AnalysisReweightMode.TRAM and thermo.energy is not None:
+            return weights.astype(np.float64, copy=False)
+        return weights.astype(np.float64, copy=False)
+
+    def _store_split_weights(
+        self,
+        dataset: AnalysisDataset,
+        split_name: str,
+        shard_id: str,
+        weights: np.ndarray,
+    ) -> None:
+        if not isinstance(dataset, MutableMapping):
+            return
+        split_map = dataset.get("splits")
+        if isinstance(split_map, MutableMapping):
+            split = split_map.get(split_name)
+            if isinstance(split, MutableMapping):
+                split["weights"] = weights
+        cache = dataset.setdefault("__weights__", {})
+        if isinstance(cache, MutableMapping):
+            cache[shard_id] = weights

--- a/src/pmarlo/workflow/finalize.py
+++ b/src/pmarlo/workflow/finalize.py
@@ -1,0 +1,109 @@
+"""Lightweight MSM/FES finalisation pipeline for precomputed projections."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Mapping, MutableMapping
+
+import numpy as np
+
+from ..analysis import compute_weighted_fes, prepare_msm_discretization, compute_diagnostics
+from ..reweight import AnalysisReweightMode, Reweighter
+
+DatasetLike = MutableMapping[str, Any] | Mapping[str, Any]
+
+
+@dataclass(slots=True)
+class AnalysisConfig:
+    """Configuration for the analysis finalisation pipeline."""
+
+    temperature_ref_K: float = 300.0
+    lag_time: int = 1
+    n_microstates: int = 150
+    cluster_mode: str = "kmeans"
+    reweight: str = AnalysisReweightMode.MBAR
+    fes_bins: int = 64
+    fes_split: str | None = "train"
+    fes_method: str = "kde"
+    fes_bandwidth: str | float = "scott"
+    fes_min_count_per_bin: int = 1
+    apply_whitening: bool = True
+
+
+def _normalise_reweight_mode(mode: str | None) -> str:
+    if mode is None:
+        return AnalysisReweightMode.NONE
+    return AnalysisReweightMode.normalise(mode)
+
+
+def finalize_dataset(dataset: DatasetLike, cfg: AnalysisConfig) -> Dict[str, Any]:
+    """Run MSM discretisation and FES estimation with optional reweighting."""
+
+    if not isinstance(dataset, (MutableMapping, dict)):
+        raise ValueError("Dataset must be a mutable mapping of splits and metadata")
+
+    reweight_mode = _normalise_reweight_mode(cfg.reweight)
+    weights: Dict[str, np.ndarray] | None = None
+    effective_mode = AnalysisReweightMode.NONE
+
+    if reweight_mode != AnalysisReweightMode.NONE:
+        reweighter = Reweighter(cfg.temperature_ref_K)
+        try:
+            weights = reweighter.apply(dataset, mode=reweight_mode)
+            effective_mode = reweight_mode
+        except Exception:
+            weights = None
+            effective_mode = AnalysisReweightMode.NONE
+    else:
+        effective_mode = AnalysisReweightMode.NONE
+
+    msm = prepare_msm_discretization(
+        dataset,
+        cluster_mode=cfg.cluster_mode,
+        n_microstates=cfg.n_microstates,
+        lag_time=cfg.lag_time,
+        frame_weights=weights,
+        random_state=None,
+        apply_whitening=bool(cfg.apply_whitening),
+    )
+
+    counts = np.asarray(msm.counts, dtype=np.float64)
+    row_sums = counts.sum(axis=1)
+    total = float(np.sum(row_sums))
+    if total > 0 and counts.shape[0] > 0:
+        pi = row_sums / total
+    elif counts.shape[0] > 0:
+        pi = np.full((counts.shape[0],), 1.0 / counts.shape[0], dtype=np.float64)
+    else:
+        pi = np.asarray([], dtype=np.float64)
+
+    fes = compute_weighted_fes(
+        dataset,
+        split=cfg.fes_split,
+        weights=None,
+        bins=cfg.fes_bins,
+        temperature_K=cfg.temperature_ref_K,
+        method=cfg.fes_method,
+        bandwidth=cfg.fes_bandwidth,
+        min_count_per_bin=cfg.fes_min_count_per_bin,
+        apply_whitening=bool(cfg.apply_whitening),
+    )
+
+    diagnostics = compute_diagnostics(dataset, diag_mass=msm.diag_mass)
+
+    result: Dict[str, Any] = {
+        "msm": msm,
+        "transition_matrix": msm.transition_matrix,
+        "counts": counts,
+        "stationary_distribution": pi,
+        "lag_time": msm.lag_time,
+        "diag_mass": msm.diag_mass,
+        "reweight_mode": effective_mode,
+        "fes": fes,
+        "diagnostics": diagnostics,
+    }
+    if weights is not None:
+        result["frame_weights"] = weights
+    if diagnostics.get("warnings"):
+        result["warnings"] = diagnostics["warnings"]
+    return result

--- a/tests/analysis/test_diagnostics.py
+++ b/tests/analysis/test_diagnostics.py
@@ -1,0 +1,65 @@
+import importlib
+import pathlib
+import sys
+import types
+
+import numpy as np
+
+
+def _load_compute_diagnostics():
+    for name in list(sys.modules):
+        if name.startswith("pmarlo.analysis") or name.startswith("pmarlo.ml"):
+            sys.modules.pop(name)
+    base = pathlib.Path("src/pmarlo")
+    pkg = types.ModuleType("pmarlo")
+    pkg.__path__ = [str(base)]
+    sys.modules["pmarlo"] = pkg
+    ml_pkg = types.ModuleType("pmarlo.ml")
+    ml_pkg.__path__ = []
+    sys.modules["pmarlo.ml"] = ml_pkg
+    deeptica_pkg = types.ModuleType("pmarlo.ml.deeptica")
+    deeptica_pkg.__path__ = []
+    sys.modules["pmarlo.ml.deeptica"] = deeptica_pkg
+    whitening_mod = types.ModuleType("pmarlo.ml.deeptica.whitening")
+
+    def _identity(values, mean=None, transform=None, already_applied=None):
+        return np.asarray(values, dtype=np.float64)
+
+    whitening_mod.apply_output_transform = _identity
+    sys.modules["pmarlo.ml.deeptica.whitening"] = whitening_mod
+    importlib.invalidate_caches()
+    diagnostics_mod = importlib.import_module("pmarlo.analysis.diagnostics")
+    compute = diagnostics_mod.compute_diagnostics
+    for name in (
+        "pmarlo.ml.deeptica.whitening",
+        "pmarlo.ml.deeptica",
+        "pmarlo.ml",
+        "pmarlo.analysis.diagnostics",
+        "pmarlo.analysis",
+        "pmarlo",
+    ):
+        sys.modules.pop(name, None)
+    return compute
+
+
+def test_compute_diagnostics_triviality_and_mass_warning():
+    X = np.random.default_rng(0).normal(size=(200, 2))
+    dataset = {"splits": {"train": {"X": X, "inputs": X.copy()}}}
+    compute_diagnostics = _load_compute_diagnostics()
+    result = compute_diagnostics(dataset, diag_mass=0.99)
+
+    canon = result.get("canonical_correlation", {})
+    assert "train" in canon and canon["train"], "expected canonical correlations for train split"
+    warnings = result.get("warnings", [])
+    assert any("reparametrize" in w for w in warnings)
+    assert any("MSM diagonal mass" in w for w in warnings)
+
+
+def test_compute_diagnostics_handles_missing_inputs():
+    rng = np.random.default_rng(2)
+    dataset = {"splits": {"train": {"X": rng.normal(size=(40, 2))}}}
+    compute_diagnostics = _load_compute_diagnostics()
+    result = compute_diagnostics(dataset, diag_mass=0.1)
+
+    assert result.get("canonical_correlation", {}) == {}
+    assert "train" in result.get("autocorrelation", {})

--- a/tests/analysis/test_discretize.py
+++ b/tests/analysis/test_discretize.py
@@ -1,0 +1,132 @@
+import importlib
+import pathlib
+import sys
+import types
+
+import numpy as np
+
+
+def _prepare_imports():
+    if "pmarlo.analysis.msm" in sys.modules:
+        del sys.modules["pmarlo.analysis.msm"]
+    if "pmarlo.analysis" in sys.modules:
+        del sys.modules["pmarlo.analysis"]
+    if "pmarlo" in sys.modules:
+        del sys.modules["pmarlo"]
+
+    base = pathlib.Path("src/pmarlo")
+    pmarlo_pkg = types.ModuleType("pmarlo")
+    pmarlo_pkg.__path__ = [str(base)]
+    sys.modules["pmarlo"] = pmarlo_pkg
+
+    ml_pkg = sys.modules.setdefault("pmarlo.ml", types.ModuleType("pmarlo.ml"))
+    if not hasattr(ml_pkg, "__path__"):
+        ml_pkg.__path__ = []  # pragma: no cover - defensive for namespace packages
+
+    deeptica_pkg = types.ModuleType("pmarlo.ml.deeptica")
+    deeptica_pkg.__path__ = []
+    sys.modules["pmarlo.ml.deeptica"] = deeptica_pkg
+
+    whitening_mod = types.ModuleType("pmarlo.ml.deeptica.whitening")
+
+    def _identity_transform(Y, mean, W, already_applied):
+        return np.asarray(Y, dtype=np.float64)
+
+    whitening_mod.apply_output_transform = _identity_transform
+    sys.modules["pmarlo.ml.deeptica.whitening"] = whitening_mod
+    deeptica_pkg.apply_output_transform = _identity_transform
+
+    analysis_mod = importlib.import_module("pmarlo.analysis.msm")
+    return analysis_mod.prepare_msm_discretization
+
+
+def _make_dataset(train, val=None, test=None):
+    splits = {"train": {"X": np.asarray(train, dtype=np.float64)}}
+    if val is not None:
+        splits["val"] = {"X": np.asarray(val, dtype=np.float64)}
+    if test is not None:
+        splits["test"] = {"X": np.asarray(test, dtype=np.float64)}
+    return {"splits": splits}
+
+
+def test_prepare_msm_discretization_kmeans_assigns_all_splits():
+    prepare_msm_discretization = _prepare_imports()
+    train = np.array([[0.0, 0.0], [0.1, -0.1], [4.0, 4.0], [4.2, 3.9]])
+    val = np.array([[0.05, 0.05], [4.1, 4.1]])
+    test = np.array([[0.2, -0.05]])
+    dataset = _make_dataset(train, val=val, test=test)
+
+    result = prepare_msm_discretization(
+        dataset,
+        n_microstates=2,
+        lag_time=1,
+        random_state=0,
+    )
+
+    assert set(result.assignments) == {"train", "val", "test"}
+    assert result.counts.shape == (2, 2)
+    for name, arr in result.assignments.items():
+        assert arr.shape[0] == dataset["splits"][name]["X"].shape[0]
+
+
+def test_weighted_counts_use_starting_frame_weights():
+    prepare_msm_discretization = _prepare_imports()
+    train = np.array(
+        [
+            [0.0, 0.0],
+            [0.05, -0.05],
+            [5.0, 5.0],
+            [5.1, 5.2],
+        ],
+        dtype=np.float64,
+    )
+    weights = np.array([1.0, 0.5, 2.0, 3.0])
+    dataset = _make_dataset(train)
+
+    result = prepare_msm_discretization(
+        dataset,
+        n_microstates=2,
+        lag_time=1,
+        frame_weights={"train": weights},
+        random_state=0,
+    )
+
+    labels = result.assignments["train"]
+    expected = np.zeros_like(result.counts)
+    for idx in range(labels.size - 1):
+        expected[labels[idx], labels[idx + 1]] += weights[idx]
+    assert np.allclose(result.counts, expected)
+
+
+def test_grid_mode_discretization_creates_states():
+    prepare_msm_discretization = _prepare_imports()
+    train = np.array([[0.0], [0.2], [1.0], [1.2]])
+    dataset = _make_dataset(train)
+
+    result = prepare_msm_discretization(
+        dataset,
+        cluster_mode="grid",
+        n_microstates=4,
+        lag_time=1,
+    )
+
+    assert result.cluster_mode == "grid"
+    assert result.counts.shape[0] >= 1
+    assert result.transition_matrix.shape == result.counts.shape
+
+
+def test_frame_weights_length_mismatch_raises():
+    prepare_msm_discretization = _prepare_imports()
+    train = np.array([[0.0, 0.0], [1.0, 1.0]])
+    dataset = _make_dataset(train)
+
+    try:
+        prepare_msm_discretization(
+            dataset,
+            n_microstates=2,
+            frame_weights={"train": np.array([1.0])},
+        )
+    except ValueError as exc:
+        assert "Frame weights" in str(exc)
+    else:
+        raise AssertionError("Expected ValueError for mismatched weights")

--- a/tests/analysis/test_fes.py
+++ b/tests/analysis/test_fes.py
@@ -1,0 +1,99 @@
+import importlib
+import pathlib
+import sys
+import types
+
+import numpy as np
+
+
+def _load_compute_weighted_fes():
+    for name in list(sys.modules):
+        if name == "pmarlo" or name.startswith("pmarlo."):
+            sys.modules.pop(name)
+
+    base = pathlib.Path("src/pmarlo")
+    pmarlo_pkg = types.ModuleType("pmarlo")
+    pmarlo_pkg.__path__ = [str(base)]
+    sys.modules["pmarlo"] = pmarlo_pkg
+
+    ml_pkg = types.ModuleType("pmarlo.ml")
+    ml_pkg.__path__ = []
+    sys.modules["pmarlo.ml"] = ml_pkg
+
+    deeptica_pkg = types.ModuleType("pmarlo.ml.deeptica")
+    deeptica_pkg.__path__ = []
+    sys.modules["pmarlo.ml.deeptica"] = deeptica_pkg
+
+    whitening_mod = types.ModuleType("pmarlo.ml.deeptica.whitening")
+
+    def _identity_transform(Y, mean, W, already_applied):
+        return np.asarray(Y, dtype=np.float64)
+
+    whitening_mod.apply_output_transform = _identity_transform
+    sys.modules["pmarlo.ml.deeptica.whitening"] = whitening_mod
+    deeptica_pkg.apply_output_transform = _identity_transform
+
+    fes_mod = importlib.import_module("pmarlo.analysis.fes")
+    return fes_mod.compute_weighted_fes
+
+
+compute_weighted_fes = _load_compute_weighted_fes()
+
+
+def _make_dataset(points: np.ndarray) -> dict:
+    return {"splits": {"train": {"X": np.asarray(points, dtype=np.float64)}}}
+
+
+def test_kde_surface_metadata_and_shape():
+    rng = np.random.default_rng(4)
+    cluster_a = rng.normal(loc=[-1.0, -0.5], scale=0.15, size=(80, 2))
+    cluster_b = rng.normal(loc=[1.1, 0.7], scale=0.12, size=(70, 2))
+    dataset = _make_dataset(np.vstack([cluster_a, cluster_b]))
+
+    fes = compute_weighted_fes(dataset, method="kde", bins=16, bandwidth="scott")
+
+    density = fes["histogram"]
+    assert density.shape == (16, 16)
+    assert np.all(np.isfinite(density))
+    assert np.min(density) > 0.0
+
+    metadata = fes["metadata"]
+    assert metadata["method"] == "kde"
+    assert metadata["bandwidth"]["selector"] == "scott"
+    assert metadata["bandwidth"]["x"] > 0.0
+    assert metadata["bandwidth"]["y"] > 0.0
+
+
+def test_grid_smoothing_applies_neighbor_floor():
+    points = np.array(
+        [
+            [0.02, 0.01],
+            [0.03, -0.02],
+            [-0.01, 0.04],
+            [0.02, 0.03],
+            [0.01, -0.01],
+        ],
+        dtype=np.float64,
+    )
+    dataset = _make_dataset(points)
+
+    fes = compute_weighted_fes(
+        dataset,
+        method="grid",
+        bins=(6, 6),
+        min_count_per_bin=3,
+    )
+
+    hist = fes["histogram"]
+    assert hist.shape == (6, 6)
+
+    metadata = fes["metadata"]
+    assert metadata["method"] == "grid"
+    assert metadata["min_count_per_bin"] == 3
+    assert metadata["smoothed_bins"] > 0
+    assert metadata.get("smoothing") == "neighbor_average"
+
+    # Bins neighbouring the populated cell should have received mass.
+    zero_fraction = np.count_nonzero(hist == 0.0) / hist.size
+    assert zero_fraction < 0.8
+

--- a/tests/analysis/test_finalize.py
+++ b/tests/analysis/test_finalize.py
@@ -1,0 +1,137 @@
+import copy
+import importlib
+import pathlib
+import sys
+import types
+
+import numpy as np
+
+
+_KB_KJ_PER_MOL = 0.00831446261815324
+
+
+def _prepare_modules():
+    for name in list(sys.modules):
+        if name.startswith("pmarlo.workflow.finalize"):
+            sys.modules.pop(name)
+        if name.startswith("pmarlo.reweight"):
+            sys.modules.pop(name)
+        if name == "pmarlo.analysis" or name.startswith("pmarlo.analysis."):
+            sys.modules.pop(name)
+
+    base = pathlib.Path("src/pmarlo")
+    pmarlo_pkg = types.ModuleType("pmarlo")
+    pmarlo_pkg.__path__ = [str(base)]
+    sys.modules["pmarlo"] = pmarlo_pkg
+
+    ml_pkg = sys.modules.setdefault("pmarlo.ml", types.ModuleType("pmarlo.ml"))
+    if not hasattr(ml_pkg, "__path__"):
+        ml_pkg.__path__ = []
+
+    deeptica_pkg = types.ModuleType("pmarlo.ml.deeptica")
+    deeptica_pkg.__path__ = []
+    sys.modules["pmarlo.ml.deeptica"] = deeptica_pkg
+
+    whitening_mod = types.ModuleType("pmarlo.ml.deeptica.whitening")
+
+    def _identity_transform(Y, mean, W, already_applied):
+        return np.asarray(Y, dtype=np.float64)
+
+    whitening_mod.apply_output_transform = _identity_transform
+    sys.modules["pmarlo.ml.deeptica.whitening"] = whitening_mod
+    deeptica_pkg.apply_output_transform = _identity_transform
+
+    finalize_mod = importlib.import_module("pmarlo.workflow.finalize")
+    reweight_mod = importlib.import_module("pmarlo.reweight")
+    AnalysisConfig = finalize_mod.AnalysisConfig
+    finalize_dataset = finalize_mod.finalize_dataset
+    AnalysisReweightMode = reweight_mod.AnalysisReweightMode
+    return AnalysisConfig, finalize_dataset, AnalysisReweightMode
+
+
+def _biased_dataset(seed: int = 0) -> dict:
+    rng = np.random.default_rng(seed)
+    low = rng.normal(loc=[-1.5, -1.0], scale=0.05, size=(60, 2))
+    high = rng.normal(loc=[1.5, 1.0], scale=0.05, size=(60, 2))
+    X = np.vstack([low, high]).astype(np.float64)
+    energy = np.concatenate(
+        [
+            np.full(low.shape[0], -5.0, dtype=np.float64),
+            np.full(high.shape[0], 12.0, dtype=np.float64),
+        ]
+    )
+    bias = np.zeros_like(energy)
+    beta = 1.0 / (_KB_KJ_PER_MOL * 450.0)
+    dataset = {
+        "splits": {
+            "train": {
+                "X": X,
+                "energy": energy,
+                "bias": bias,
+                "beta": beta,
+                "meta": {"shard_id": "demo-train"},
+            }
+        }
+    }
+    return dataset
+
+
+def test_finalize_reweight_changes_stationary_and_fes():
+    AnalysisConfig, finalize_dataset, AnalysisReweightMode = _prepare_modules()
+    dataset = _biased_dataset()
+
+    cfg_none = AnalysisConfig(
+        temperature_ref_K=300.0,
+        lag_time=1,
+        n_microstates=3,
+        cluster_mode="kmeans",
+        reweight=AnalysisReweightMode.NONE,
+        fes_bins=16,
+    )
+    result_none = finalize_dataset(copy.deepcopy(dataset), cfg_none)
+
+    cfg_weighted = AnalysisConfig(
+        temperature_ref_K=300.0,
+        lag_time=1,
+        n_microstates=3,
+        cluster_mode="kmeans",
+        reweight=AnalysisReweightMode.MBAR,
+        fes_bins=16,
+    )
+    result_weighted = finalize_dataset(copy.deepcopy(dataset), cfg_weighted)
+
+    assert result_weighted["reweight_mode"] == AnalysisReweightMode.MBAR
+    assert "frame_weights" in result_weighted
+    weights_train = result_weighted["frame_weights"]["train"]
+    assert np.isclose(weights_train.sum(), 1.0)
+
+    pi_none = result_none["stationary_distribution"]
+    pi_weighted = result_weighted["stationary_distribution"]
+    assert pi_none.shape == pi_weighted.shape
+    assert not np.allclose(pi_none, pi_weighted)
+
+    fes_none = result_none["fes"]["free_energy"]
+    fes_weighted = result_weighted["fes"]["free_energy"]
+    assert fes_none.shape == fes_weighted.shape
+    assert np.max(np.abs(fes_none - fes_weighted)) > 1e-6
+
+    assert "diagnostics" in result_none
+    assert isinstance(result_none["diagnostics"], dict)
+    assert "diagnostics" in result_weighted
+
+
+def test_finalize_falls_back_without_thermo_information():
+    AnalysisConfig, finalize_dataset, AnalysisReweightMode = _prepare_modules()
+    dataset = {
+        "splits": {
+            "train": {
+                "X": np.random.default_rng(1).normal(size=(20, 2)),
+                "meta": {"shard_id": "train"},
+            }
+        }
+    }
+    cfg = AnalysisConfig(reweight=AnalysisReweightMode.MBAR, n_microstates=3)
+    result = finalize_dataset(dataset, cfg)
+
+    assert result["reweight_mode"] == AnalysisReweightMode.NONE
+    assert "frame_weights" not in result


### PR DESCRIPTION
## Summary
- add Streamlit helpers to persist tau schedules, discretization, reweighting, and FES options in the UI and restore them when loading saved assets
- extend the app backend training and build configurations to capture the new schedule, clustering, and reweighting parameters while recording them in state and build flags
- allow the MSM and FES helpers plus the finalize workflow to respect a whitening toggle controlled from the UI

## Testing
- `PYTHONPATH=src python - <<'PY'
from tests.analysis import test_discretize, test_fes, test_finalize

for module in (test_discretize, test_fes, test_finalize):
    for name in dir(module):
        if name.startswith('test_'):
            getattr(module, name)()
print('selected analysis tests passed')
PY`


------
https://chatgpt.com/codex/tasks/task_e_68cd689a829c832e9af149c3869c3368