### PR TITLE
Refactor IO helpers to satisfy complexity checks

### DIFF
--- a/changelog.d/20250218_000000_io_complexity_refactor.md
+++ b/changelog.d/20250218_000000_io_complexity_refactor.md
@@ -1,0 +1,2 @@
+### Changed
+- Refactored DeepTICA export helper and MDTraj DCD buffer flushing into smaller helpers to satisfy complexity gates without altering behaviour.

--- a/src/pmarlo/io/export.py
+++ b/src/pmarlo/io/export.py
@@ -9,6 +9,61 @@ from typing import Any
 import torch
 
 
+def _save_model_state(model: Any, ckpt_path: str | None, out: Path) -> None:
+    state_dict = getattr(model, "state_dict", None)
+    payload = {
+        "state_dict": state_dict() if callable(state_dict) else {},
+        "ckpt": ckpt_path,
+    }
+    torch.save(payload, out / "model.pt")
+
+
+def _save_scaler(scaler: Any, out: Path) -> None:
+    try:
+        torch.save(scaler, out / "scaler.pt")
+        return
+    except Exception:
+        pass
+
+    try:
+        import numpy as np  # lazy import
+
+        params = {
+            "mean": np.asarray(getattr(scaler, "mean_", None)),
+            "std": np.asarray(getattr(scaler, "scale_", None)),
+        }
+        torch.save(params, out / "scaler.pt")
+    except Exception:
+        pass
+
+
+def _write_metadata(metadata: dict[str, Any], out: Path) -> None:
+    (out / "config.json").write_text(
+        json.dumps(metadata, indent=2, sort_keys=True), encoding="utf-8"
+    )
+
+
+def _maybe_copy_history(model: Any, metadata: dict[str, Any], out: Path) -> None:
+    metrics_csv = _resolve_metrics_path(model, metadata)
+    if metrics_csv is None:
+        return
+    try:
+        src = Path(str(metrics_csv))
+        if src.exists():
+            shutil.copyfile(str(src), out / "history.csv")
+    except Exception:
+        pass
+
+
+def _resolve_metrics_path(model: Any, metadata: dict[str, Any]) -> Path | str | None:
+    if hasattr(model, "training_history"):
+        maybe_history = getattr(model, "training_history", {})
+        metrics_csv = maybe_history.get("metrics_csv")
+        if metrics_csv:
+            return metrics_csv
+    return metadata.get("metrics_csv")
+
+
 def export_deeptica_bundle(
     model,
     scaler,
@@ -27,53 +82,9 @@ def export_deeptica_bundle(
     out = Path(out_dir)
     out.mkdir(parents=True, exist_ok=True)
 
-    # Model state
-    torch.save(
-        {
-            "state_dict": (
-                getattr(model, "state_dict")() if hasattr(model, "state_dict") else {}
-            ),
-            "ckpt": ckpt_path,
-        },
-        out / "model.pt",
-    )
-
-    # Scaler
-    try:
-        torch.save(scaler, out / "scaler.pt")
-    except Exception:
-        # Fallback to saving parameters
-        try:
-            import numpy as np  # lazy
-
-            torch.save(
-                {
-                    "mean": np.asarray(getattr(scaler, "mean_", None)),
-                    "std": np.asarray(getattr(scaler, "scale_", None)),
-                },
-                out / "scaler.pt",
-            )
-        except Exception:
-            pass
-
-    # Config/metadata
-    (out / "config.json").write_text(
-        json.dumps(metadata, indent=2, sort_keys=True), encoding="utf-8"
-    )
-
-    # Try copying metrics.csv as history.csv
-    try:
-        metrics_csv = None
-        # Accept both attributes on model or metadata
-        if hasattr(model, "training_history"):
-            metrics_csv = getattr(model, "training_history", {}).get("metrics_csv")
-        if not metrics_csv:
-            metrics_csv = metadata.get("metrics_csv")
-        if metrics_csv:
-            src = Path(str(metrics_csv))
-            if src.exists():
-                shutil.copyfile(str(src), str(out / "history.csv"))
-    except Exception:
-        pass
+    _save_model_state(model, ckpt_path, out)
+    _save_scaler(scaler, out)
+    _write_metadata(metadata, out)
+    _maybe_copy_history(model, metadata, out)
 
     return out


### PR DESCRIPTION
## Summary
- split the DeepTICA export bundle helper into focused helpers so the main function meets the complexity gate
- modularized the MDTraj DCD writer buffer flushing logic into smaller helpers to keep behaviour while reducing complexity
- documented the refactor in the changelog

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68d402dad108832eb67b53ec9cb0ebde